### PR TITLE
Feat : RequestMatcherHolder 도입을 통해 특정 엔드포인트에 대한 불필요한 인증 절차 제거

### DIFF
--- a/src/main/java/com/grepp/teamnotfound/app/controller/api/TestController.java
+++ b/src/main/java/com/grepp/teamnotfound/app/controller/api/TestController.java
@@ -4,7 +4,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;

--- a/src/main/java/com/grepp/teamnotfound/app/controller/api/admin/AdminController.java
+++ b/src/main/java/com/grepp/teamnotfound/app/controller/api/admin/AdminController.java
@@ -1,4 +1,4 @@
-package com.grepp.teamnotfound.app.controller.api;
+package com.grepp.teamnotfound.app.controller.api.admin;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/com/grepp/teamnotfound/app/controller/api/auth/AuthController.java
+++ b/src/main/java/com/grepp/teamnotfound/app/controller/api/auth/AuthController.java
@@ -1,4 +1,4 @@
-package com.grepp.teamnotfound.app.controller.api;
+package com.grepp.teamnotfound.app.controller.api.auth;
 
 import com.grepp.teamnotfound.app.model.auth.AuthService;
 import com.grepp.teamnotfound.app.model.auth.payload.LoginRequest;
@@ -23,7 +23,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/auth")
-public class UserController {
+public class AuthController {
 
     private final AuthService authService;
     private final UserService userService;

--- a/src/main/java/com/grepp/teamnotfound/infra/auth/token/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/grepp/teamnotfound/infra/auth/token/filter/JwtAuthenticationFilter.java
@@ -1,7 +1,7 @@
 package com.grepp.teamnotfound.infra.auth.token.filter;
 
-import com.grepp.teamnotfound.app.model.auth.token.dto.AccessTokenDto;
 import com.grepp.teamnotfound.app.model.auth.token.RefreshTokenService;
+import com.grepp.teamnotfound.app.model.auth.token.dto.AccessTokenDto;
 import com.grepp.teamnotfound.app.model.auth.token.entity.RefreshToken;
 import com.grepp.teamnotfound.app.model.auth.token.entity.UserBlackList;
 import com.grepp.teamnotfound.app.model.auth.token.repository.UserBlackListRepository;
@@ -10,6 +10,7 @@ import com.grepp.teamnotfound.infra.auth.token.TokenCookieFactory;
 import com.grepp.teamnotfound.infra.auth.token.code.TokenType;
 import com.grepp.teamnotfound.infra.error.exception.CommonException;
 import com.grepp.teamnotfound.infra.error.exception.code.AuthErrorCode;
+import com.grepp.teamnotfound.infra.util.requestmatcher.RequestMatcherHolder;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import jakarta.servlet.FilterChain;
@@ -22,13 +23,9 @@ import org.springframework.http.ResponseCookie;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
-import org.springframework.util.AntPathMatcher;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
 
 @Component
 @RequiredArgsConstructor
@@ -39,19 +36,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final RefreshTokenService refreshTokenService;
     private final UserBlackListRepository userBlackListRepository;
 
-    private final AntPathMatcher pathMatcher = new AntPathMatcher();
+    private final RequestMatcherHolder requestMatcherHolder;
 
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
-        List<String> excludePath = new ArrayList<>();
-        excludePath.addAll(List.of("/error", "/favicon.ico", "/img","/download"));
-
-        excludePath.addAll(List.of("/api/auth/v1/register", "/api/auth/v1/login", "/api/auth/v1/test"));
-        excludePath.addAll(List.of("/api/auth/v1/admin/register", "/api/auth/v1/admin/login"));
-        excludePath.addAll(List.of("/swagger-ui","/swagger-ui/**","/swagger-ui.html",
-                "/v3/api-docs", "/v3/api-docs/swagger-config","/v3/api-docs/**"));
-        String path = request.getRequestURI();
-        return excludePath.stream().anyMatch(path::startsWith);
+        return requestMatcherHolder.getRequestMatchersByMinRole(null).matches(request);
     }
 
     @Override

--- a/src/main/java/com/grepp/teamnotfound/infra/util/requestmatcher/RequestMatcherHolder.java
+++ b/src/main/java/com/grepp/teamnotfound/infra/util/requestmatcher/RequestMatcherHolder.java
@@ -1,0 +1,77 @@
+package com.grepp.teamnotfound.infra.util.requestmatcher;
+
+import org.springframework.http.HttpMethod;
+import org.springframework.lang.Nullable;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.security.web.util.matcher.OrRequestMatcher;
+import org.springframework.security.web.util.matcher.RequestMatcher;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+import static org.springframework.http.HttpMethod.GET;
+import static org.springframework.http.HttpMethod.POST;
+
+@Component
+public class RequestMatcherHolder {
+
+    private record RequestInfo(HttpMethod method, String pattern, @Nullable String minRole) {
+    }
+
+    private static final List<RequestInfo> REQUEST_INFO_LIST = List.of(
+
+            // 1. common
+            new RequestInfo(null, "/", null),
+            new RequestInfo(null, "/error", null),
+            new RequestInfo(null, "/favicon.ico", null),
+
+            // 2. auth 로그인/회원가입
+            new RequestInfo(POST, "/api/auth/v1/register/**", null),
+            new RequestInfo(POST,"/api/auth/v1/login", null),
+            new RequestInfo(POST, "/api/auth/v1/admin/register", null),
+            new RequestInfo(POST, "/api/auth/v1/admin/login", null),
+
+            // 3. admin
+            new RequestInfo(null, "/api/admin/**", "ADMIN"),
+
+            // 4. swagger
+            new RequestInfo(null, "/swagger-ui.html", null),
+            new RequestInfo(null, "/swagger-ui/**", null),
+            new RequestInfo(null, "/v3/api-docs/**", null),
+            new RequestInfo(null, "/swagger-resources/**", null),
+            new RequestInfo(null, "/webjars/**", null),
+
+            // 5. 기타 개발용 open page
+            // GET /**
+            new RequestInfo(GET, "/**", null)
+    );
+
+    // 캐싱 맵
+    private final ConcurrentHashMap<String, RequestMatcher> reqMatcherCacheMap = new ConcurrentHashMap<>();
+
+    public RequestMatcher getRequestMatchersByMinRole(@Nullable String minRole) {
+        var key = getKeyByRole(minRole);
+        return reqMatcherCacheMap.computeIfAbsent(key, k ->
+                new OrRequestMatcher(REQUEST_INFO_LIST.stream()
+
+                        // minRole이 불일치 하면 필터링
+                        .filter(reqInfo -> Objects.equals(reqInfo.minRole(), minRole))
+                        .map(reqInfo -> {
+                            // httpMethod == null -> 모든 메소드를 매칭하는 Ant 생성
+                            if (reqInfo.method() == null) {
+                                return new AntPathRequestMatcher(reqInfo.pattern());
+                            } else {
+                                // httpMethod가 있을 경우 해당 메소드만 매칭 antPath 생성
+                                return new AntPathRequestMatcher(reqInfo.pattern(), reqInfo.method().name());
+                            }
+                        })
+                        .collect(Collectors.toList())));
+    }
+
+    private String getKeyByRole(@Nullable String minRole) {
+        return minRole == null ? "VISITOR" : minRole;
+    }
+}


### PR DESCRIPTION
### 💡 구현 내용
RequestMatcherHolder 도입을 통한 JwtAuthenticationFilter, SecurityConfig 개선

**1. 이슈 배경**
- 기존 `SecurityConfig`에서는 `httpMethod`와 `API 경로`별로 `authenticated()` 또는 `permitAll()` 설정을 세밀하게 관리
- `JwtAuthenticationFilter`를 통해 모든 요청에 대해 jwt 기반의 인가 검증
    - 이때 `shouldNotFilter` 메서드를 사용해 특정 요청에 대해 jwt 검증을 건너뛸 수 있으나,
    - `/**` 와일드 카드 패턴 작동하지 않음
    - `HttpMethod`별 구분 불가(GET, POST가 각각 다른 접근을 제어가 어려움

**2. 문제점**
- `permitAll()`로 열어둔 경로임에도, `JwtAuthenticationFilter`에서 다시 별도로 `shouldNotFilter` 설정 필요 → 중복 관리
- `shouldNotFilter()`는 `HttpMethod`를 구분하지 않아, 오버로딩된 메서드에 대해 불필요한 인증 요구가 발생
- 결과적으로 `JwtAuthenticationFilter`와 `SecurityConfig`를 따로 설정해야 하여, 유지보수 부담이 큼

**3. 개선 목표**
- 중복되는 경로를 한 곳에서 통합적으로 관리
- `HttpMethod`까지 포함하여 인가 검증

**4. 구체적 구현 내용**
- `RequestMatcherHolder` 클래스를 도입하여, `HttpMethod`, 경로, 최소 권한을 기준으로 `matcher` 리스트를 생성
- `RequestMatcherHolder`를 `SecurityConfig`와 `JwtAuthenticationFilter` 에 주입하여, 경로 제어의 단일 책임을 보장
- `shouldNotFilter`는 이 `matcher` 리스트를 기반으로 인증을 생략할 요청을 판단하도록 변경