### PR TITLE
Fix : 인증 객체 userId 기준으로 제작 및 TokenBlackList accessToken 값으로 생성

### DIFF
--- a/src/main/java/com/grepp/teamnotfound/app/controller/api/auth/AuthController.java
+++ b/src/main/java/com/grepp/teamnotfound/app/controller/api/auth/AuthController.java
@@ -35,30 +35,30 @@ public class AuthController {
 
     @Operation(summary = "이메일 중복 확인")
     @GetMapping("v1/check-email")
-    public ResponseEntity<ApiResponse<?>> checkEmail(@RequestParam("email") String email) {
+    public ResponseEntity<?> checkEmail(@RequestParam("email") String email) {
         userService.validateEmailDuplication(email);
-        return ResponseEntity.ok(ApiResponse.success("사용 가능한 이메일입니다."));
+        return ResponseEntity.ok("사용 가능한 이메일입니다.");
     }
 
     @Operation(summary = "이메일 인증코드 발송 요청")
     @PostMapping("v1/email-verifications")
-    public ResponseEntity<ApiResponse<?>> emailVerification(@RequestBody EmailVerificationRequest request) {
+    public ResponseEntity<?> emailVerification(@RequestBody EmailVerificationRequest request) {
         userService.sendEmail(request.getEmail());
-        return ResponseEntity.ok(ApiResponse.success("인증 코드가 발송되었습니다."));
+        return ResponseEntity.ok("인증 코드가 발송되었습니다.");
     }
 
     @Operation(summary = "이메일 인증코드 검증")
     @PostMapping("v1/email-verifications/verify")
-    public ResponseEntity<ApiResponse<?>> emailVerify(@RequestBody EmailVerifyRequest request) {
+    public ResponseEntity<?> emailVerify(@RequestBody EmailVerifyRequest request) {
         mailService.verifyEmailCode(request.getEmail(), request.getVerificationCode());
-        return ResponseEntity.ok(ApiResponse.success("인증코드가 올바르게 인증되었습니다"));
+        return ResponseEntity.ok("인증코드가 올바르게 인증되었습니다");
     }
 
     @Operation(summary = "닉네임 중복 확인")
     @GetMapping("v1/check-nickname")
-    public ResponseEntity<ApiResponse<?>> checkNickname(@RequestParam("nickname") String nickname) {
+    public ResponseEntity<?> checkNickname(@RequestParam("nickname") String nickname) {
         userService.validateNicknameDuplication(nickname);
-        return ResponseEntity.ok(ApiResponse.success("사용 가능한 닉네임입니다."));
+        return ResponseEntity.ok("사용 가능한 닉네임입니다.");
     }
 
     @Operation(summary = "최종 회원가입")

--- a/src/main/java/com/grepp/teamnotfound/app/model/auth/AuthService.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/auth/AuthService.java
@@ -14,6 +14,7 @@ import com.grepp.teamnotfound.infra.auth.token.JwtProvider;
 import com.grepp.teamnotfound.infra.auth.token.code.GrantType;
 import com.grepp.teamnotfound.infra.error.exception.AuthException;
 import com.grepp.teamnotfound.infra.error.exception.code.AuthErrorCode;
+import com.grepp.teamnotfound.infra.error.exception.code.UserErrorCode;
 import io.jsonwebtoken.Claims;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -37,7 +38,8 @@ public class AuthService {
 
 
     public TokenDto login(LoginCommand request) {
-        User user = userService.findByEmail(request.getEmail());
+        User user = userService.findByEmail(request.getEmail())
+                .orElseThrow(() -> new AuthException(UserErrorCode.USER_NOT_FOUND));
 
         UsernamePasswordAuthenticationToken authenticationToken =
                 new UsernamePasswordAuthenticationToken(

--- a/src/main/java/com/grepp/teamnotfound/app/model/auth/AuthService.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/auth/AuthService.java
@@ -54,9 +54,6 @@ public class AuthService {
 
     private TokenDto processTokenLogin(Long userId) {
 
-        // TODO TokenBlackList id 값 email > userId
-//        tokenBlackListRepository.deleteById(userId);
-
         AccessTokenDto accessToken = jwtProvider.generateAccessToken(userId);
         RefreshToken refreshToken = refreshTokenService.saveWithAtId(accessToken.getId());
 
@@ -77,8 +74,6 @@ public class AuthService {
             throw new AuthException(AuthErrorCode.TOKEN_EXPIRED);
         }
 
-        // TODO blackList
-        String userEmail = claims.getSubject();
         String accessTokenId = claims.getId();
 
         // 0. 블랙리스트 확인

--- a/src/main/java/com/grepp/teamnotfound/app/model/auth/UserDetailsServiceImpl.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/auth/UserDetailsServiceImpl.java
@@ -1,5 +1,6 @@
 package com.grepp.teamnotfound.app.model.auth;
 
+import com.grepp.teamnotfound.app.model.auth.domain.Principal;
 import com.grepp.teamnotfound.app.model.user.entity.User;
 import com.grepp.teamnotfound.app.model.user.repository.UserRepository;
 import com.grepp.teamnotfound.infra.error.exception.BusinessException;
@@ -31,24 +32,12 @@ public class UserDetailsServiceImpl implements UserDetailsService {
         User user = userRepository.findByEmail(username)
                 .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
 
-        return new org.springframework.security.core.userdetails.User(
+        return new Principal(
+                user.getUserId(),
                 user.getEmail(),
                 user.getPassword(),
                 Collections.singletonList(
                         new SimpleGrantedAuthority(user.getRole().name()))
         );
     }
-
-    @Cacheable("user-authorities")
-    public List<SimpleGrantedAuthority> findAuthorities(String username){
-        User user = userRepository.findByEmail(username)
-                .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
-
-        List<SimpleGrantedAuthority> authorities = new ArrayList<>();
-
-        authorities.add(new SimpleGrantedAuthority(user.getRole().name()));
-
-        return authorities;
-    }
-
 }

--- a/src/main/java/com/grepp/teamnotfound/app/model/auth/UserDetailsServiceImpl.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/auth/UserDetailsServiceImpl.java
@@ -7,7 +7,6 @@ import com.grepp.teamnotfound.infra.error.exception.BusinessException;
 import com.grepp.teamnotfound.infra.error.exception.code.UserErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.cache.annotation.Cacheable;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
@@ -15,9 +14,7 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
 import java.util.Collections;
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/com/grepp/teamnotfound/app/model/auth/domain/Principal.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/auth/domain/Principal.java
@@ -6,9 +6,18 @@ import org.springframework.security.core.userdetails.User;
 
 import java.util.Collection;
 
+// 인증용 Spring.User 상속
 public class Principal extends User {
-    public Principal(String username, String password, Collection<? extends GrantedAuthority> authorities) {
+
+    private final Long userId;
+
+    public Principal(Long userId, String username, String password, Collection<? extends GrantedAuthority> authorities) {
         super(username, password, authorities);
+        this.userId = userId;
+    }
+
+    public Long getUserId() {
+        return userId;
     }
 
 }

--- a/src/main/java/com/grepp/teamnotfound/app/model/auth/domain/Principal.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/auth/domain/Principal.java
@@ -1,12 +1,14 @@
 package com.grepp.teamnotfound.app.model.auth.domain;
 
 
+import lombok.Getter;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.User;
 
 import java.util.Collection;
 
 // 인증용 Spring.User 상속
+@Getter
 public class Principal extends User {
 
     private final Long userId;
@@ -14,10 +16,6 @@ public class Principal extends User {
     public Principal(Long userId, String username, String password, Collection<? extends GrantedAuthority> authorities) {
         super(username, password, authorities);
         this.userId = userId;
-    }
-
-    public Long getUserId() {
-        return userId;
     }
 
 }

--- a/src/main/java/com/grepp/teamnotfound/app/model/auth/token/RefreshTokenService.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/auth/token/RefreshTokenService.java
@@ -30,13 +30,13 @@ public class RefreshTokenService {
     }
 
     // 신규 refreshToken 발급 로직
-    public RefreshToken renewingToken(String id, String newTokenId) {
-        RefreshToken refreshToken = findByAccessTokenId(id);
+    public RefreshToken renewingToken(String oldTokenId, String newTokenId) {
+        RefreshToken refreshToken = findByAccessTokenId(oldTokenId);
 
         if(refreshToken == null) return null;
 
         // 지연시간 동안 사용할 ttl 10초 짜리
-        RefreshToken gracePeriodToken = new RefreshToken(id);
+        RefreshToken gracePeriodToken = new RefreshToken(oldTokenId);
         gracePeriodToken.setToken(refreshToken.getToken());
 
         // 기존 refresh token 변경
@@ -44,7 +44,7 @@ public class RefreshTokenService {
         refreshToken.setAtId(newTokenId);
 
         redisTemplate.opsForValue().set(newTokenId, refreshToken, Duration.ofSeconds(refreshToken.getTtl()));
-        redisTemplate.opsForValue().set(id, gracePeriodToken, Duration.ofSeconds(1000));
+        redisTemplate.opsForValue().set(oldTokenId, gracePeriodToken, Duration.ofSeconds(1000));
         return refreshToken;
     }
 

--- a/src/main/java/com/grepp/teamnotfound/app/model/auth/token/entity/TokenBlackList.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/auth/token/entity/TokenBlackList.java
@@ -10,19 +10,19 @@ import java.time.OffsetDateTime;
 
 @Getter
 @Setter
-@RedisHash("userBlackList")
-public class UserBlackList {
+@RedisHash("tokenBlackList")
+public class TokenBlackList {
 
     @Id
-    private String email;
+    private String accessToken;
     private OffsetDateTime createdAt = OffsetDateTime.now();
 
     @TimeToLive
     private Long expiration;
 
     // 이메일과 TTL을 받는 생성자
-    public UserBlackList(String email, Long expiration) {
-        this.email = email;
+    public TokenBlackList(String accessToken, Long expiration) {
+        this.accessToken = accessToken;
         this.expiration = expiration;
     }
 

--- a/src/main/java/com/grepp/teamnotfound/app/model/auth/token/repository/TokenBlackListRepository.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/auth/token/repository/TokenBlackListRepository.java
@@ -1,0 +1,7 @@
+package com.grepp.teamnotfound.app.model.auth.token.repository;
+
+import com.grepp.teamnotfound.app.model.auth.token.entity.TokenBlackList;
+import org.springframework.data.repository.CrudRepository;
+
+public interface TokenBlackListRepository extends CrudRepository<TokenBlackList, String> {
+}

--- a/src/main/java/com/grepp/teamnotfound/app/model/auth/token/repository/UserBlackListRepository.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/auth/token/repository/UserBlackListRepository.java
@@ -1,7 +1,0 @@
-package com.grepp.teamnotfound.app.model.auth.token.repository;
-
-import com.grepp.teamnotfound.app.model.auth.token.entity.UserBlackList;
-import org.springframework.data.repository.CrudRepository;
-
-public interface UserBlackListRepository extends CrudRepository<UserBlackList, String> {
-}

--- a/src/main/java/com/grepp/teamnotfound/app/model/user/UserService.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/user/UserService.java
@@ -18,6 +18,8 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Optional;
+
 @Service
 @Slf4j
 @RequiredArgsConstructor
@@ -105,8 +107,7 @@ public class UserService {
         });
     }
 
-    public User findByEmail(String email) {
-        return userRepository.findByEmail(email)
-                .orElseThrow(() -> new AuthException(UserErrorCode.USER_NOT_FOUND));
+    public Optional<User> findByEmail(String email) {
+        return userRepository.findByEmail(email);
     }
 }

--- a/src/main/java/com/grepp/teamnotfound/app/model/user/UserService.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/user/UserService.java
@@ -1,15 +1,16 @@
 package com.grepp.teamnotfound.app.model.user;
 
 import com.grepp.teamnotfound.app.model.auth.code.Role;
-import com.grepp.teamnotfound.infra.util.mail.MailService;
 import com.grepp.teamnotfound.app.model.user.dto.RegisterCommand;
 import com.grepp.teamnotfound.app.model.user.dto.UserDto;
 import com.grepp.teamnotfound.app.model.user.dto.UserImgDto;
 import com.grepp.teamnotfound.app.model.user.entity.User;
 import com.grepp.teamnotfound.app.model.user.entity.UserImg;
 import com.grepp.teamnotfound.app.model.user.repository.UserRepository;
+import com.grepp.teamnotfound.infra.error.exception.AuthException;
 import com.grepp.teamnotfound.infra.error.exception.BusinessException;
 import com.grepp.teamnotfound.infra.error.exception.code.UserErrorCode;
+import com.grepp.teamnotfound.infra.util.mail.MailService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.modelmapper.ModelMapper;
@@ -102,5 +103,10 @@ public class UserService {
         userRepository.findByNickname(nickname).ifPresent(user -> {
             throw new BusinessException(UserErrorCode.USER_NICKNAME_ALREADY_EXISTS);
         });
+    }
+
+    public User findByEmail(String email) {
+        return userRepository.findByEmail(email)
+                .orElseThrow(() -> new AuthException(UserErrorCode.USER_NOT_FOUND));
     }
 }

--- a/src/main/java/com/grepp/teamnotfound/app/model/user/entity/UserDetailsImpl.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/user/entity/UserDetailsImpl.java
@@ -31,6 +31,10 @@ public class UserDetailsImpl implements UserDetails {
         return user.getEmail();
     }
 
+    public Long getUserId(){
+        return user.getUserId();
+    }
+
     @Override
     public boolean isAccountNonExpired() {
         return true;

--- a/src/main/java/com/grepp/teamnotfound/app/model/user/repository/UserRepository.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/user/repository/UserRepository.java
@@ -11,5 +11,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByNickname(String nickname);
 
+    //TODO Optional<User>
     User findByUserId(Long userId);
 }

--- a/src/main/java/com/grepp/teamnotfound/infra/auth/token/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/grepp/teamnotfound/infra/auth/token/filter/JwtAuthenticationFilter.java
@@ -128,8 +128,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     }
 
     // accessToken 재발급 시, refreshToken 재발급 로직
-    private RefreshToken renewingRefreshToken(String id, String newTokenId) {
-        return refreshTokenService.renewingToken(id, newTokenId);
+    private RefreshToken renewingRefreshToken(String oldTokenId, String newTokenId) {
+        return refreshTokenService.renewingToken(oldTokenId, newTokenId);
     }
 
     // 응답에 쿠키로 토큰 전달

--- a/src/main/java/com/grepp/teamnotfound/infra/auth/token/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/grepp/teamnotfound/infra/auth/token/filter/JwtAuthenticationFilter.java
@@ -3,8 +3,8 @@ package com.grepp.teamnotfound.infra.auth.token.filter;
 import com.grepp.teamnotfound.app.model.auth.token.RefreshTokenService;
 import com.grepp.teamnotfound.app.model.auth.token.dto.AccessTokenDto;
 import com.grepp.teamnotfound.app.model.auth.token.entity.RefreshToken;
-import com.grepp.teamnotfound.app.model.auth.token.entity.UserBlackList;
-import com.grepp.teamnotfound.app.model.auth.token.repository.UserBlackListRepository;
+import com.grepp.teamnotfound.app.model.auth.token.entity.TokenBlackList;
+import com.grepp.teamnotfound.app.model.auth.token.repository.TokenBlackListRepository;
 import com.grepp.teamnotfound.infra.auth.token.JwtProvider;
 import com.grepp.teamnotfound.infra.auth.token.TokenCookieFactory;
 import com.grepp.teamnotfound.infra.auth.token.code.TokenType;
@@ -34,7 +34,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtProvider jwtProvider;
     private final RefreshTokenService refreshTokenService;
-    private final UserBlackListRepository userBlackListRepository;
+    private final TokenBlackListRepository tokenBlackListRepository;
 
     private final RequestMatcherHolder requestMatcherHolder;
 
@@ -61,7 +61,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         // 2. parseClaim - // 블랙리스트 filtering
         Claims claims = jwtProvider.parseClaims(accessToken);
-        if(userBlackListRepository.existsById(claims.getSubject())){
+        if(tokenBlackListRepository.existsById(claims.getId())){
             throw new CommonException(AuthErrorCode.INVALID_TOKEN);
         }
 
@@ -109,7 +109,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
             // 유효 시간이 있을 때만 blacklist 처리
             if (remainingExpirationSeconds > 0) {
-                userBlackListRepository.save(new UserBlackList(authentication.getName(), remainingExpirationSeconds));
+                tokenBlackListRepository.save(new TokenBlackList(claims.getId(), remainingExpirationSeconds));
                 throw new CommonException(AuthErrorCode.SECURITY_INCIDENT);
             } else {
                 // access 만료 + re 만료 : 아예 자격이 없음

--- a/src/main/java/com/grepp/teamnotfound/infra/auth/token/filter/LogoutFilter.java
+++ b/src/main/java/com/grepp/teamnotfound/infra/auth/token/filter/LogoutFilter.java
@@ -36,7 +36,7 @@ public class LogoutFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
 
         String path = request.getRequestURI();
-        if (!path.equals("/api/v1/auth/logout")) {
+        if (!path.equals("/api/auth/v1/logout")) {
             filterChain.doFilter(request, response);
             return;
         }

--- a/src/main/java/com/grepp/teamnotfound/infra/config/SecurityConfig.java
+++ b/src/main/java/com/grepp/teamnotfound/infra/config/SecurityConfig.java
@@ -36,11 +36,11 @@ public class SecurityConfig {
 
     private final AuthExceptionFilter authExceptionFilter;
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
-    private final LogoutFilter logoutFilter;
+//    private final LogoutFilter logoutFilter;
     private final RequestMatcherHolder requestMatcherHolder;
 
     @Bean
-    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    public SecurityFilterChain securityFilterChain(HttpSecurity http, LogoutFilter logoutFilter) throws Exception {
 
         RequestMatcher permitAllMatcher = requestMatcherHolder.getRequestMatchersByMinRole(null);
         RequestMatcher adminMatcher = requestMatcherHolder.getRequestMatchersByMinRole("ADMIN");

--- a/src/main/java/com/grepp/teamnotfound/infra/error/exception/advice/GlobalExceptionHandler.java
+++ b/src/main/java/com/grepp/teamnotfound/infra/error/exception/advice/GlobalExceptionHandler.java
@@ -1,11 +1,14 @@
 package com.grepp.teamnotfound.infra.error.exception.advice;
 
 import com.grepp.teamnotfound.infra.error.exception.CommonException;
+import com.grepp.teamnotfound.infra.error.exception.code.AuthErrorCode;
 import com.grepp.teamnotfound.infra.error.exception.dto.ErrorResponse;
+import com.grepp.teamnotfound.infra.response.ApiResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authorization.AuthorizationDeniedException;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -56,6 +59,18 @@ public class GlobalExceptionHandler {
                         "AUTH_002",
                         "접근 권한이 없습니다.",
                         LocalDateTime.now()));
+    }
+
+    @ExceptionHandler(BadCredentialsException.class)
+    public ResponseEntity<ErrorResponse> handleBadCredentials(BadCredentialsException e) {
+        return ResponseEntity
+                .status(HttpStatus.UNAUTHORIZED)
+                .body(new ErrorResponse(
+                        HttpStatus.UNAUTHORIZED.value(),
+                        "AUTH_001",
+                        "자격 증명에 실패하였습니다.",
+                        LocalDateTime.now()
+                ));
     }
 
     // 그 외 모든 Exception catch

--- a/src/main/java/com/grepp/teamnotfound/infra/error/exception/advice/GlobalExceptionHandler.java
+++ b/src/main/java/com/grepp/teamnotfound/infra/error/exception/advice/GlobalExceptionHandler.java
@@ -67,8 +67,8 @@ public class GlobalExceptionHandler {
                 .status(HttpStatus.UNAUTHORIZED)
                 .body(new ErrorResponse(
                         HttpStatus.UNAUTHORIZED.value(),
-                        "AUTH_001",
-                        "자격 증명에 실패하였습니다.",
+                        "USER_002",
+                        "아이디 또는 비밀번호가 일치하지 않습니다.",
                         LocalDateTime.now()
                 ));
     }


### PR DESCRIPTION
## ✅ PR 올리기 전에
- [x] `dev`에서 `pull` 받았나요?
- [x] `merge conflict` 발생 시, 해결하고 올리셨나요?
- [x] 자신이 작업한 `changes`만 존재하나요?

## 🐶 구현한 기능

## 🔎 작업 내용
- 기존에 email로 제작하던 인증 객체를 userId 기준으로 수정
- 기존에 email을 BlackList에 삽입하던 로직을 accessToken 값이 삽입되도록 수정
- 이외 각종 오류 및 예외처리, 응답 수정

## 📣 공유 사항
로그인 후 접근하는 요청의 경우 Controller에서 매개로 "**`@AuthenticationPrincipal` UserDetailsImpl userDetails**" 넣으면,
인증 객체의 user 값을 직접 가져올 수 있습니다.
(종욱님께서 사용하신 선례가 있어서, 조금 수정한 예제 코드를 갖고 왔습니다)
<img width="782" height="697" alt="userDetails" src="https://github.com/user-attachments/assets/556d8a5f-22a7-4df2-bcca-04658a736f54" />
###  ‼️사용 방법 및 사용 시 유의점
- 매개변수로 `@AuthenticationPrincipal` 사용하면, AuthenticationFtilter에서 걸러 인가된(로그인한) 사용자를 가져옵니다.
- spring의 `UserDetails`가 아닌, 404TNF의 `UserDetailsImpl`을 import 해야 합니다.
- `getUsername()`은 로그인 한 사용자의 email 값을 의미합니다. 
(인터페이스 필수 오버라이딩 메서드라 userEmail로 수정 불가)
- `getUserId()`로, 로그인 한 사용자의 userId 값을 바로 가져올 수 있습니다.
- `getUser()`로, 로그인 한 사용자의 User 객체를 가져올 수 있으나, 캐싱된 값+JPA가 관리하지 않는 값이므로, 영속성 오류 및 최신화가 안 되어 있을 수 있습니다.
    - 같은 이유로 `userDetails.getUser().getUserId()`, `userDetails.getUser.getUserImg()` 등의 사용은 지양(사용 x)해야 합니다.
    - `userDetais.getUserId()` 역시 캐싱된 값이므로, POST, PATCH 등 사용 시에는 `UserRepo.findByEmail` 같은 메서드로 한 번 더 조회하는 것을 추천드립니다!!

