### PR TITLE
Fix : age 계산 일괄 삭제 오류 해결

### DIFF
--- a/src/main/java/com/grepp/teamnotfound/app/model/pet/PetService.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/pet/PetService.java
@@ -15,6 +15,7 @@ import com.grepp.teamnotfound.infra.error.exception.code.UserErrorCode;
 import com.grepp.teamnotfound.util.NotFoundException;
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
+import java.time.Period;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -58,12 +59,9 @@ public class PetService {
         return pets.stream()
             .map(pet -> {
                 ProfilePetResponse dto = modelMapper.map(pet, ProfilePetResponse.class);
-
-                if (pet.getMetday() != null) {
-                    dto.setDays((int) ChronoUnit.DAYS.between(pet.getMetday(), LocalDate.now()) + 1);
-                } else {
-                    dto.setDays(null);
-                }
+                dto.setPetId(pet.getPetId());
+                dto.setDays((int) ChronoUnit.DAYS.between(pet.getMetday(), LocalDate.now()) + 1);
+                dto.setAge(calculateAge(pet.getBirthday()));
 
                 return dto;
             })
@@ -122,5 +120,13 @@ public class PetService {
         }
 
         vaccinationService.softDelete(petId);
+    }
+
+    private Integer calculateAge(LocalDate birthday) {
+        if (birthday == null) {
+            return null;
+        }
+        Period period = Period.between(birthday, LocalDate.now());
+        return period.getYears() * 12 + period.getMonths();
     }
 }


### PR DESCRIPTION
## ✅ PR 올리기 전에
- [x] `dev`에서 `pull` 받았나요?
- [x] `merge conflict` 발생 시, 해결하고 올리셨나요?
- [x] 자신이 작업한 `changes`만 존재하나요?

## 🔎 작업 내용
age 필드 삭제 후, 관련 로직을 일괄로 지워버리는 바람에 필요한 부분도 null값으로 가게 되었습니다.
profile에서도 age 잘 받아올 수 있도록 수정했습니다.
(petId값과 userId값을 혼동해서 보내주어 petId를 null로 보내는 경우도 있는 것 같아서,, petId도 set으로 지정해서 보내주게 했습니다.)

