### PR TITLE
fix : 일정 조회 시 petId, petName 추가

### DIFF
--- a/src/main/java/com/grepp/teamnotfound/app/controller/api/schedule/ScheduleApiController.java
+++ b/src/main/java/com/grepp/teamnotfound/app/controller/api/schedule/ScheduleApiController.java
@@ -30,12 +30,12 @@ public class ScheduleApiController {
     // 일정 조회 시 한달치의 일정 넘기기
     @GetMapping("/{userId}/calendar")
     public ResponseEntity<?> getPetCalendar(
-            @RequestParam String userEmail,
+            @RequestParam Long userId,
             @RequestParam LocalDate date
             ){
         //todo 요청한 유저가 맞는지 검증로직
 
-        List<ScheduleDto> schedules = scheduleService.getCalendar(userEmail, date);
+        List<ScheduleDto> schedules = scheduleService.getCalendar(userId, date);
 
         return ResponseEntity.ok(Map.of("data", schedules));
     }

--- a/src/main/java/com/grepp/teamnotfound/app/model/schedule/ScheduleService.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/schedule/ScheduleService.java
@@ -37,15 +37,15 @@ public class ScheduleService {
     private final UserRepository userRepository;
 
     // 한달치 일정 조회
-    public List<ScheduleDto> getCalendar(String userEmail, LocalDate date) {
+    public List<ScheduleDto> getCalendar(Long userId, LocalDate date) {
         // user 검증
-        User user = userRepository.findByEmail(userEmail).orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+        User user = userRepository.findById(userId).orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
 
         YearMonth ym = YearMonth.from(date);
         LocalDate start = ym.atDay(1);
         LocalDate end = ym.atEndOfMonth();
 
-        List<Schedule> schedules = scheduleRepository.findByUserAndScheduleDateBetweenAndDeletedAtNull(user, start, end);
+        List<Schedule> schedules = scheduleRepository.findMonthListByUser(user, start, end);
         List<ScheduleDto> scheduleDtos = new ArrayList<>();
         schedules.forEach(schedule ->
                 scheduleDtos.add(ScheduleDto.builder()
@@ -54,7 +54,9 @@ public class ScheduleService {
                         .name(schedule.getName())
                         .cycle(schedule.getCycle())
                         .cycleEnd(schedule.getCycleEnd())
-                        .isDone(schedule.getIsDone()).build())
+                        .isDone(schedule.getIsDone())
+                        .petName(schedule.getPet().getName())
+                        .petId(schedule.getPet().getPetId()).build())
         );
 
         return scheduleDtos;

--- a/src/main/java/com/grepp/teamnotfound/app/model/schedule/ScheduleService.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/schedule/ScheduleService.java
@@ -37,6 +37,7 @@ public class ScheduleService {
     private final UserRepository userRepository;
 
     // 한달치 일정 조회
+    @Transactional
     public List<ScheduleDto> getCalendar(Long userId, LocalDate date) {
         // user 검증
         User user = userRepository.findById(userId).orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
@@ -45,7 +46,7 @@ public class ScheduleService {
         LocalDate start = ym.atDay(1);
         LocalDate end = ym.atEndOfMonth();
 
-        List<Schedule> schedules = scheduleRepository.findMonthListByUser(user, start, end);
+        List<Schedule> schedules = scheduleRepository.findByUserAndScheduleDateBetweenAndDeletedAtNull(user, start, end);
         List<ScheduleDto> scheduleDtos = new ArrayList<>();
         schedules.forEach(schedule ->
                 scheduleDtos.add(ScheduleDto.builder()

--- a/src/main/java/com/grepp/teamnotfound/app/model/schedule/dto/ScheduleDto.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/schedule/dto/ScheduleDto.java
@@ -3,14 +3,18 @@ package com.grepp.teamnotfound.app.model.schedule.dto;
 import com.grepp.teamnotfound.app.model.schedule.code.ScheduleCycle;
 import lombok.Builder;
 import lombok.Data;
+import lombok.ToString;
 
 import java.time.LocalDate;
 
 @Builder
 @Data
+@ToString
 public class ScheduleDto {
     private Long scheduleId;
     private LocalDate date;
+    private Long petId;
+    private String petName;
     private String name;
     private Boolean isDone;
     private ScheduleCycle cycle;

--- a/src/main/java/com/grepp/teamnotfound/app/model/schedule/repository/ScheduleRepository.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/schedule/repository/ScheduleRepository.java
@@ -5,6 +5,8 @@ import com.grepp.teamnotfound.app.model.schedule.code.ScheduleCycle;
 import com.grepp.teamnotfound.app.model.schedule.entity.Schedule;
 import com.grepp.teamnotfound.app.model.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -13,5 +15,16 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
 
     List<Schedule> findByNameAndCycleAndCycleEnd(String name, ScheduleCycle cycle, LocalDate cycleEnd);
 
-    List<Schedule> findByUserAndScheduleDateBetweenAndDeletedAtNull(User user, LocalDate start, LocalDate end);
+    @Query("""
+           select s
+           from   Schedule s
+           join   fetch s.pet p
+           where  s.user         = :user
+             and  s.scheduleDate between :start and :end
+             and  s.deletedAt    is null
+           """)
+    List<Schedule> findMonthListByUser(
+            @Param("user")  User      user,
+            @Param("start") LocalDate start,
+            @Param("end")   LocalDate end);
 }

--- a/src/main/java/com/grepp/teamnotfound/app/model/schedule/repository/ScheduleRepository.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/schedule/repository/ScheduleRepository.java
@@ -15,16 +15,5 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
 
     List<Schedule> findByNameAndCycleAndCycleEnd(String name, ScheduleCycle cycle, LocalDate cycleEnd);
 
-    @Query("""
-           select s
-           from   Schedule s
-           join   fetch s.pet p
-           where  s.user         = :user
-             and  s.scheduleDate between :start and :end
-             and  s.deletedAt    is null
-           """)
-    List<Schedule> findMonthListByUser(
-            @Param("user")  User      user,
-            @Param("start") LocalDate start,
-            @Param("end")   LocalDate end);
+    List<Schedule> findByUserAndScheduleDateBetweenAndDeletedAtNull(User user, LocalDate start, LocalDate end);
 }

--- a/src/main/java/com/grepp/teamnotfound/infra/config/SwaggerConfig.java
+++ b/src/main/java/com/grepp/teamnotfound/infra/config/SwaggerConfig.java
@@ -22,9 +22,9 @@ public class SwaggerConfig {
                         .description("API 명세입니다. 에러 코드는 [링크]를 참조해 주세요.")
                         .version("v1.0.0"))
                 // todo 배포할 때만 허용...
-                .servers(List.of(
-                        new Server().url("https://mungnote-172598302113.asia-northeast3.run.app")
-                ))
+//                .servers(List.of(
+//                        new Server().url("https://mungnote-172598302113.asia-northeast3.run.app")
+//                ))
                 .components(
                         new Components()
                                 .addSecuritySchemes("bearerAuth"

--- a/src/test/java/com/grepp/teamnotfound/app/model/schedule/ScheduleServiceTest.java
+++ b/src/test/java/com/grepp/teamnotfound/app/model/schedule/ScheduleServiceTest.java
@@ -4,6 +4,7 @@ import com.grepp.teamnotfound.app.controller.api.schedule.payload.ScheduleCreate
 import com.grepp.teamnotfound.app.controller.api.schedule.payload.ScheduleEditRequest;
 import com.grepp.teamnotfound.app.model.schedule.code.ScheduleCycle;
 import com.grepp.teamnotfound.app.model.schedule.dto.ScheduleCreateRequestDto;
+import com.grepp.teamnotfound.app.model.schedule.dto.ScheduleDto;
 import com.grepp.teamnotfound.app.model.schedule.dto.ScheduleEditRequestDto;
 import com.grepp.teamnotfound.app.model.schedule.entity.Schedule;
 import org.junit.jupiter.api.Test;
@@ -23,9 +24,8 @@ class ScheduleServiceTest {
     // 일정 조회
     @Test
     void getCalendar() {
-        List<Schedule> schedules = scheduleService.getCalendar("email@email.com", LocalDate.now());
-        assertNotNull(schedules);
-        assertTrue(schedules.size() >= 0);
+        List<ScheduleDto> schedules = scheduleService.getCalendar(10000L, LocalDate.now());
+        System.out.println(schedules);
     }
 
     // 반복 없는 일정 등록


### PR DESCRIPTION
## ✅ PR 올리기 전에
- [x] `dev`에서 `pull` 받았나요?
- [x] `merge conflict` 발생 시, 해결하고 올리셨나요?
- [x] 자신이 작업한 `changes`만 존재하나요?

## 🐶 구현한 기능
일정 조회 시 petId, petName을 같이 넘기도록 수정했습니다.

## 🔎 작업 내용


## 📣 공유 사항

