### PR TITLE
feat/fix : 일정 로직 변경

### DIFF
--- a/src/main/java/com/grepp/teamnotfound/app/controller/api/schedule/ScheduleApiController.java
+++ b/src/main/java/com/grepp/teamnotfound/app/controller/api/schedule/ScheduleApiController.java
@@ -2,6 +2,7 @@ package com.grepp.teamnotfound.app.controller.api.schedule;
 
 import com.grepp.teamnotfound.app.controller.api.schedule.payload.ScheduleCreateRequest;
 import com.grepp.teamnotfound.app.controller.api.schedule.payload.ScheduleEditRequest;
+import com.grepp.teamnotfound.app.model.auth.domain.Principal;
 import com.grepp.teamnotfound.app.model.schedule.ScheduleService;
 import com.grepp.teamnotfound.app.model.schedule.dto.ScheduleCreateRequestDto;
 import com.grepp.teamnotfound.app.model.schedule.dto.ScheduleDto;
@@ -12,6 +13,8 @@ import org.modelmapper.ModelMapper;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDate;
@@ -22,67 +25,67 @@ import java.util.Map;
 @AllArgsConstructor
 @RestController
 @RequestMapping(value = "/api/v1/dashboard", produces = MediaType.APPLICATION_JSON_VALUE)
+@PreAuthorize("isAuthenticated()")
 public class ScheduleApiController {
 
     private ScheduleService scheduleService;
     ModelMapper modelMapper = new ModelMapper();
 
     // 일정 조회 시 한달치의 일정 넘기기
-    @GetMapping("/{userId}/calendar")
+    @GetMapping("/calendar")
     public ResponseEntity<?> getPetCalendar(
-            @RequestParam Long userId,
-            @RequestParam LocalDate date
-            ){
-        List<ScheduleDto> schedules = scheduleService.getCalendar(userId, date);
+            @RequestParam LocalDate date,
+            @AuthenticationPrincipal Principal principal
+    ){
+        List<ScheduleDto> schedules = scheduleService.getCalendar(principal.getUserId(), date);
 
         return ResponseEntity.ok(Map.of("data", schedules));
     }
 
-    @PostMapping("{petId}/calendar")
+    @PostMapping("/calendar")
     public ResponseEntity<?> createSchedule(
-            @PathVariable Long petId,
-            @RequestBody ScheduleCreateRequest request
+            @RequestBody ScheduleCreateRequest request,
+            @AuthenticationPrincipal Principal principal
     ){
         modelMapper.getConfiguration().setPropertyCondition(ctx -> !ctx.getMapping().getLastDestinationProperty().getName().equals("petId"));
         ScheduleCreateRequestDto requestDto = new ScheduleCreateRequestDto();
         modelMapper.map(request, requestDto);
-        requestDto.setPetId(petId);
-        scheduleService.createSchedule(requestDto);
+        requestDto.setPetId(request.getPetId());
+        scheduleService.createSchedule(principal.getUserId(), requestDto);
 
         return ResponseEntity.ok(HttpStatus.CREATED);
     }
 
-    @PatchMapping("{petId}/calendar")
+    @PatchMapping("/calendar")
     public ResponseEntity<?> EditSchedule(
-            @PathVariable Long petId,
-            @RequestBody ScheduleEditRequest request
+            @RequestBody ScheduleEditRequest request,
+            @AuthenticationPrincipal Principal principal
     ){
         modelMapper.getConfiguration().setPropertyCondition(ctx -> !ctx.getMapping().getLastDestinationProperty().getName().equals("petId"));
         ScheduleEditRequestDto requestDto = new ScheduleEditRequestDto();
         modelMapper.map(request, requestDto);
-        requestDto.setPetId(petId);
-        scheduleService.editSchedule(requestDto);
+        requestDto.setPetId(request.getPetId());
+        scheduleService.editSchedule(principal.getUserId(), requestDto);
 
         return ResponseEntity.ok(HttpStatus.ACCEPTED);
     }
 
-    @PatchMapping("{petId}/calendar/delete")
+    @PatchMapping("/calendar/delete")
     public ResponseEntity<?> DeleteSchedule(
-            @PathVariable Long petId,
-            @RequestParam Long userId,
+            @AuthenticationPrincipal Principal principal,
             @RequestParam Long scheduleId,
             @RequestParam Boolean cycleLink
     ){
-        scheduleService.deleteSchedule(userId, scheduleId, cycleLink);
+        scheduleService.deleteSchedule(principal.getUserId(), scheduleId, cycleLink);
         return ResponseEntity.ok(HttpStatus.ACCEPTED);
     }
 
-    @GetMapping("{petId}/calendar/{scheduleId}")
+    @GetMapping("/calendar/{scheduleId}")
     public ResponseEntity<?> ScheduleIsDone(
-            @PathVariable Long petId,
+            @AuthenticationPrincipal Principal principal,
             @PathVariable Long scheduleId
     ){
-        scheduleService.checkIsDone(petId, scheduleId);
+        scheduleService.checkIsDone(principal.getUserId(), scheduleId);
         return ResponseEntity.ok(HttpStatus.ACCEPTED);
     }
 }

--- a/src/main/java/com/grepp/teamnotfound/app/controller/api/schedule/ScheduleApiController.java
+++ b/src/main/java/com/grepp/teamnotfound/app/controller/api/schedule/ScheduleApiController.java
@@ -7,7 +7,6 @@ import com.grepp.teamnotfound.app.model.schedule.ScheduleService;
 import com.grepp.teamnotfound.app.model.schedule.dto.ScheduleCreateRequestDto;
 import com.grepp.teamnotfound.app.model.schedule.dto.ScheduleDto;
 import com.grepp.teamnotfound.app.model.schedule.dto.ScheduleEditRequestDto;
-import com.grepp.teamnotfound.app.model.schedule.entity.Schedule;
 import lombok.AllArgsConstructor;
 import org.modelmapper.ModelMapper;
 import org.springframework.http.HttpStatus;
@@ -18,13 +17,12 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDate;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
 @AllArgsConstructor
 @RestController
-@RequestMapping(value = "/api/v1/dashboard", produces = MediaType.APPLICATION_JSON_VALUE)
+@RequestMapping(value = "/api/dashboard/v2", produces = MediaType.APPLICATION_JSON_VALUE)
 @PreAuthorize("isAuthenticated()")
 public class ScheduleApiController {
 
@@ -70,7 +68,7 @@ public class ScheduleApiController {
         return ResponseEntity.ok(HttpStatus.ACCEPTED);
     }
 
-    @PatchMapping("/calendar/delete")
+    @DeleteMapping("/calendar/delete")
     public ResponseEntity<?> DeleteSchedule(
             @AuthenticationPrincipal Principal principal,
             @RequestParam Long scheduleId,

--- a/src/main/java/com/grepp/teamnotfound/app/controller/api/schedule/payload/ScheduleCreateRequest.java
+++ b/src/main/java/com/grepp/teamnotfound/app/controller/api/schedule/payload/ScheduleCreateRequest.java
@@ -9,7 +9,7 @@ import java.time.LocalDate;
 @Data
 @Builder
 public class ScheduleCreateRequest {
-    private Long userId;
+    private Long petId;
     private String name;
     private LocalDate date;
     private ScheduleCycle cycle;

--- a/src/main/java/com/grepp/teamnotfound/app/controller/api/schedule/payload/ScheduleEditRequest.java
+++ b/src/main/java/com/grepp/teamnotfound/app/controller/api/schedule/payload/ScheduleEditRequest.java
@@ -10,7 +10,6 @@ import java.time.LocalDate;
 @Builder
 public class ScheduleEditRequest {
     private Long scheduleId;
-    private Long userId;
     private Long petId;
     private String name;
     private LocalDate date;

--- a/src/main/java/com/grepp/teamnotfound/app/model/schedule/dto/ScheduleCreateRequestDto.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/schedule/dto/ScheduleCreateRequestDto.java
@@ -13,7 +13,6 @@ import java.time.LocalDate;
 @NoArgsConstructor
 @AllArgsConstructor
 public class ScheduleCreateRequestDto {
-    private Long userId;
     private Long petId;
     private String name;
     private LocalDate date;

--- a/src/main/java/com/grepp/teamnotfound/app/model/schedule/dto/ScheduleEditRequestDto.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/schedule/dto/ScheduleEditRequestDto.java
@@ -14,7 +14,6 @@ import java.time.LocalDate;
 @NoArgsConstructor
 public class ScheduleEditRequestDto {
     private Long scheduleId;
-    private Long userId;
     private Long petId;
     private String name;
     private LocalDate date;

--- a/src/test/java/com/grepp/teamnotfound/app/model/schedule/ScheduleServiceTest.java
+++ b/src/test/java/com/grepp/teamnotfound/app/model/schedule/ScheduleServiceTest.java
@@ -32,95 +32,93 @@ class ScheduleServiceTest {
     @Test
     void createSchedule() {
         ScheduleCreateRequestDto request = ScheduleCreateRequestDto.builder()
-                .userId(10000L)
                 .petId(10000L)
                 .name("병원가는 날")
                 .cycle(ScheduleCycle.NONE)
                 .cycleEnd(LocalDate.now())
                 .date(LocalDate.now())
                 .build();
-        scheduleService.createSchedule(request);
+        scheduleService.createSchedule(10000L, request);
     }
 
     // 반복 있는 일정 등록
     @Test
     void createCycleSchedule() {
         ScheduleCreateRequestDto request = ScheduleCreateRequestDto.builder()
-                .userId(10000L)
                 .petId(10000L)
                 .name("목욕하는 날")
                 .date(LocalDate.now())
                 .cycle(ScheduleCycle.WEEK)
                 .cycleEnd(LocalDate.now().plusMonths(1)).build();
-        scheduleService.createSchedule(request);
+        scheduleService.createSchedule(10000L, request);
     }
 
     // 반복 없는 일정 수정
     @Test
     void editSchedule() {
         ScheduleEditRequestDto request = ScheduleEditRequestDto.builder()
-                .petId(10000L).userId(10000L).scheduleId(10025L)
+                .petId(10000L).scheduleId(10025L)
                 .date(LocalDate.now().plusDays(2))
                 .name("병원가는날 수정")
                 .cycleLink(false)
                 .build();
-        scheduleService.editSchedule(request);
+        scheduleService.editSchedule(10000L, request);
     }
 
     // 반복 있는 일정 수정
     @Test
     void editCycleSchedule1() {
         ScheduleEditRequestDto request = ScheduleEditRequestDto.builder()
-                .petId(10000L).userId(10000L).scheduleId(10014L)
+                .petId(10000L).scheduleId(10014L)
                 .date(LocalDate.now().plusDays(2))
                 .name("목욕하는 날")
                 .cycleLink(true)
                 .cycle(ScheduleCycle.ONE_MONTH)
                 .cycleEnd(LocalDate.now().plusMonths(5))
                 .build();
-        scheduleService.editSchedule(request);
+        scheduleService.editSchedule(10000L, request);
     }
 
     // 반복 있는 일정 수정
     @Test
     void editCycleSchedule2() {
         ScheduleEditRequestDto request = ScheduleEditRequestDto.builder()
-                .petId(10000L).userId(10000L).scheduleId(10014L)
+                .petId(10000L).scheduleId(10014L)
                 .date(LocalDate.now().plusDays(2))
                 .name("목욕하는 날 수정")
                 .cycleLink(true)
                 .cycle(ScheduleCycle.WEEK)
                 .cycleEnd(LocalDate.now().plusMonths(5))
                 .build();
-        scheduleService.editSchedule(request);
+        scheduleService.editSchedule(10000L, request);
     }
 
     // 반복 없는 일정 반복 있게 수정
     @Test
     void editCycleSchedule3() {
         ScheduleEditRequestDto request = ScheduleEditRequestDto.builder()
-                .petId(10000L).userId(10000L).scheduleId(10013L)
+                .petId(10000L).scheduleId(10013L)
                 .date(LocalDate.now().plusDays(2))
                 .name("string aaa")
                 .cycleLink(true)
                 .cycle(ScheduleCycle.WEEK)
                 .cycleEnd(LocalDate.now().plusMonths(1))
                 .build();
-        scheduleService.editSchedule(request);
+        scheduleService.editSchedule(10000L, request);
     }
 
     // 반복 있는 일정 반복 없게 수정
     @Test
     void editCycleSchedule4() {
         ScheduleEditRequestDto request = ScheduleEditRequestDto.builder()
-                .petId(10000L).userId(10000L).scheduleId(10013L)
+                .petId(10000L).scheduleId(10013L)
                 .date(LocalDate.now().plusDays(2))
                 .name("string aaa")
                 .cycleLink(true)
                 .cycle(ScheduleCycle.NONE)
                 .cycleEnd(LocalDate.now().plusDays(2))
                 .build();
-        scheduleService.editSchedule(request);
+        scheduleService.editSchedule(10000L, request);
     }
 
     // 반복 없는 일정 삭제


### PR DESCRIPTION
## ✅ PR 올리기 전에
- [x] `dev`에서 `pull` 받았나요?
- [x] `merge conflict` 발생 시, 해결하고 올리셨나요?
- [x] 자신이 작업한 `changes`만 존재하나요?
- [ ] 작업 중 DB 변경이 발생했나요?

## 🐶 구현한 기능
- userId를 직접 받지 않도록 변경했습니다.
- 위의 작업을 하며 request 및 dto를 일부 수정하여 mapper에서 오류가 발생해 일정 등록 및 수정이 불가능하던 오류를 고쳤습니다.
- 주기가 한달이상인 일정에서 날짜가 밀리는 현상을 수정했습니다.

## 🔎 작업 내용
- request에서 userId를 모두 삭제했습니다.
- 파라미터에서도 userId 및 petId를 모두 삭제했습니다.
- 반복일정을 사이클링크 false로 하고 새로운 반복일정 생성시 반복일정이 생성이 되지 않던 로직을 수정했습니다.

## 📣 공유 사항
엔드포인트가 변경되어서 버전업 했습니다.
