### PR TITLE
Feat : 좋아요 요청 시 Redis 에 저장 & 배치처리 기능 구현

### DIFF
--- a/src/main/java/com/grepp/teamnotfound/app/controller/api/article/ArticleApiController.java
+++ b/src/main/java/com/grepp/teamnotfound/app/controller/api/article/ArticleApiController.java
@@ -103,7 +103,10 @@ public class ArticleApiController {
         @AuthenticationPrincipal Principal principal
     ) {
 //        LikeResponse response = articleService.likeArticle(articleId, principal.getUserId());
+        long before = System.currentTimeMillis();
         LikeResponse response = articleService.likeWithRedis(articleId, principal.getUserId());
+        long after = System.currentTimeMillis();
+        System.out.println(after - before);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 

--- a/src/main/java/com/grepp/teamnotfound/app/controller/api/article/ArticleApiController.java
+++ b/src/main/java/com/grepp/teamnotfound/app/controller/api/article/ArticleApiController.java
@@ -102,11 +102,7 @@ public class ArticleApiController {
         @PathVariable Long articleId,
         @AuthenticationPrincipal Principal principal
     ) {
-//        LikeResponse response = articleService.likeArticle(articleId, principal.getUserId());
-        long before = System.currentTimeMillis();
         LikeResponse response = articleService.likeWithRedis(articleId, principal.getUserId());
-        long after = System.currentTimeMillis();
-        System.out.println(after - before);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
@@ -117,7 +113,6 @@ public class ArticleApiController {
         @PathVariable Long articleId,
         @AuthenticationPrincipal Principal principal
     ) {
-//        LikeResponse response = articleService.unlikeArticle(articleId, principal.getUserId());
         LikeResponse response = articleService.unlikeWithRedis(articleId, principal.getUserId());
         return ResponseEntity.ok(ApiResponse.success(response));
     }

--- a/src/main/java/com/grepp/teamnotfound/app/controller/api/article/ArticleApiController.java
+++ b/src/main/java/com/grepp/teamnotfound/app/controller/api/article/ArticleApiController.java
@@ -133,7 +133,7 @@ public class ArticleApiController {
     public ResponseEntity<?> getLikeCount(
         @PathVariable Long articleId
     ) {
-        Integer likeCount = articleService.getLikeCount(articleId);
+        Integer likeCount = articleService.getActualLikeCount(articleId);
         return ResponseEntity.ok(ApiResponse.success(Map.of("likes", likeCount)));
     }
 

--- a/src/main/java/com/grepp/teamnotfound/app/controller/api/article/ArticleApiController.java
+++ b/src/main/java/com/grepp/teamnotfound/app/controller/api/article/ArticleApiController.java
@@ -102,7 +102,8 @@ public class ArticleApiController {
         @PathVariable Long articleId,
         @AuthenticationPrincipal Principal principal
     ) {
-        LikeResponse response = articleService.likeArticle(articleId, principal.getUserId());
+//        LikeResponse response = articleService.likeArticle(articleId, principal.getUserId());
+        LikeResponse response = articleService.likeWithRedis(articleId, principal.getUserId());
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
@@ -113,7 +114,8 @@ public class ArticleApiController {
         @PathVariable Long articleId,
         @AuthenticationPrincipal Principal principal
     ) {
-        LikeResponse response = articleService.unlikeArticle(articleId, principal.getUserId());
+//        LikeResponse response = articleService.unlikeArticle(articleId, principal.getUserId());
+        LikeResponse response = articleService.unlikeWithRedis(articleId, principal.getUserId());
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 

--- a/src/main/java/com/grepp/teamnotfound/app/model/board/ArticleService.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/board/ArticleService.java
@@ -307,8 +307,9 @@ public class ArticleService {
         return new LikeResponse(articleId, totalCount, isLiked);
     }
 
+    // 캐시에서 좋아요 수 먼저 조회
     private Integer getArticleLikeCount(Long articleId) {
-        // NOTE 게시글 좋아요 수는 게시글 리스트 조회, 상세 조회에서 모두 표시하는데 전부 이 메서드를 사용?
+        // NOTE 게시글 리스트 조회에서도 실시간 좋아요 수가 필요할까?
         Long count = redisLikeService.getArticleLikesCount(articleId);
 
         if (count == null) {
@@ -320,39 +321,9 @@ public class ArticleService {
         }
 
         return count.intValue();
-
-
-//        Set<Object> currentLikeRequests = redisLikeService.getLikeRequests(articleId);
-//        Set<Object> currentUnlikeRequests = redisLikeService.getUnlikeRequests(articleId);
-//
-//        long pendingLikes = 0;
-//        // 실제로 처리할 좋아요 요청만 카운트
-//        if (currentLikeRequests != null) {
-//            pendingLikes = currentLikeRequests.stream()
-//                .map(Object::toString)
-//                .filter(userIdStr ->
-//                    !articleLikeRepository.existsByArticle_ArticleIdAndUser_UserId(articleId,
-//                        Long.valueOf(userIdStr))
-//                )
-//                .count();
-//        }
-//
-//        long pendingUnlikes = 0;
-//        // 실제로 처리할 좋아요 취소 요청만 카운트
-//        if (currentUnlikeRequests != null) {
-//            pendingUnlikes = currentUnlikeRequests.stream()
-//                .map(Object::toString)
-//                .filter(userIdStr ->
-//                    articleLikeRepository.existsByArticle_ArticleIdAndUser_UserId(articleId,
-//                        Long.valueOf(userIdStr))
-//                )
-//                .count();
-//        }
-//
-//        // DB 에 아직 반영되지 않은 Redis 요청까지 합산하여 반환
-//        return (int) (dbLikeCount + pendingLikes - pendingUnlikes);
     }
 
+    // DB 에서 댓글 수 조회
     @Transactional(readOnly = true)
     public Integer getReplyCount(Long articleId) {
         articleRepository.findById(articleId)
@@ -362,6 +333,7 @@ public class ArticleService {
             articleId);
     }
 
+    // DB 에서 좋아요 수 조회
     @Transactional(readOnly = true)
     public Integer getActualLikeCount(Long articleId) {
         articleRepository.findById(articleId)

--- a/src/main/java/com/grepp/teamnotfound/app/model/board/LikeBatchProcessor.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/board/LikeBatchProcessor.java
@@ -5,6 +5,7 @@ import com.grepp.teamnotfound.app.model.board.repository.ArticleLikeRepository;
 import com.grepp.teamnotfound.app.model.board.repository.ArticleRepository;
 import com.grepp.teamnotfound.app.model.user.repository.UserRepository;
 import java.time.OffsetDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -26,16 +27,21 @@ public class LikeBatchProcessor {
 
     // 1분마다 실행
 //    @Scheduled(fixedDelay = 60000)
-    @Scheduled(fixedDelay = 300000)
-    @Transactional
+//    @Scheduled(fixedDelay = 300000)
+//    @Transactional
     public void processLikeBatch() {
+        log.info("Processing likes batch...");
 
-        // NOTE 아니 모든 게시글을 가져온다고?
-        List<Long> articleIds = articleRepository.findAllArticleIds();
+        Set<Long> changedArticleIds = redisLikeService.getAllChangedArticleIdsAndClear();
 
-        for (Long articleId : articleIds) {
-            Set<Object> likeRequests = redisLikeService.getLikeRequests(articleId);
-            Set<Object> unlikeRequests = redisLikeService.getUnlikeRequests(articleId);
+        if (changedArticleIds.isEmpty()) {
+            log.info("No changed article found. Skipping batch processing.");
+            return;
+        }
+
+        for (Long articleId : changedArticleIds) {
+            Set<Object> likeRequests = redisLikeService.getAllLikeRequestsAndClear(articleId);
+            Set<Object> unlikeRequests = redisLikeService.getAllUnlikeRequestsAndClear(articleId);
 
             // 좋아요 요청 처리
             if (likeRequests != null && !likeRequests.isEmpty()) {
@@ -45,10 +51,9 @@ public class LikeBatchProcessor {
 
                 for (Long userId : usersToLike) {
                     // DB 에 해당 좋아요가 없는 경우만 추가
-                    if (!articleLikeRepository.existsByArticle_ArticleIdAndUser_UserId(articleId,
-                        userId)) {
+                    if (!articleLikeRepository.existsByArticle_ArticleIdAndUser_UserId(articleId, userId)) {
                         articleLikeRepository.save(
-                            // getReferenceById() 는 단순한 관계설정을 위한 엔티티 호출
+                            // getReferenceById 는 단순한 관계설정을 위한 엔티티 호출(DB에 접근하지 않음)
                             ArticleLike.builder()
                                 .article(articleRepository.getReferenceById(articleId))
                                 .user(userRepository.getReferenceById(userId))
@@ -72,11 +77,61 @@ public class LikeBatchProcessor {
                         .ifPresent(articleLikeRepository::delete);
                 }
             }
-
-            // 처리 완료된 Redis 배치 요청 데이터 비우기
-            redisLikeService.clearLikeRequests(articleId);
         }
 
-        log.info("Likes batch processing finished");
+        log.info("Likes batch processing finished for {} articles.", changedArticleIds.size());
+    }
+
+    // 1분마다 실행
+    @Scheduled(fixedDelay = 300000)
+    @Transactional
+    public void processLikeBatch2() {
+        log.info("Processing likes batch...");
+
+        Set<Long> changedArticleIds = redisLikeService.getAllChangedArticleIdsAndClear();
+
+        if (changedArticleIds.isEmpty()) {
+            log.info("No changed article found. Skipping batch processing.");
+            return;
+        }
+
+        for (Long articleId : changedArticleIds) {
+            Set<Object> likeRequests = redisLikeService.getAllLikeRequestsAndClear(articleId);
+            Set<Object> unlikeRequests = redisLikeService.getAllUnlikeRequestsAndClear(articleId);
+
+            List<Long> usersToLike = likeRequests.stream()
+                .map(object -> Long.valueOf(object.toString()))
+                .toList();
+
+            List<Long> usersToUnlike = unlikeRequests.stream()
+                .map(object -> Long.valueOf(object.toString()))
+                .toList();
+
+            // 좋아요를 한꺼번에 INSERT
+            // NOTE 단순 반복문을 사용하면 너무 잦은 I/O 로 Redis 를 도입한 장점이 사라짐
+            if (!usersToLike.isEmpty()) {
+                List<Long> alreadyLiked = articleLikeRepository.findUserIdsByArticleId(articleId);
+
+                List<ArticleLike> likesToInsert = usersToLike.stream()
+                    .filter(userId -> !alreadyLiked.contains(userId))
+                    .map(userId -> ArticleLike.builder()
+                        .article(articleRepository.getReferenceById(articleId))
+                        .user(userRepository.getReferenceById(userId))
+                        .createdAt(OffsetDateTime.now())
+                        .build()
+                    ).toList();
+
+                articleLikeRepository.saveAll(likesToInsert);
+            }
+
+            // 좋아요를 한꺼번에 DELETE
+            if (!usersToUnlike.isEmpty()) {
+                // NOTE 나중에 성능이 안나온다면 JPQL 쿼리로 직접 DELETE 쿼리 날려보기
+                List<ArticleLike> likesToDelete = articleLikeRepository.findAllByArticleIdAndUserIds(articleId, usersToUnlike);
+                articleLikeRepository.deleteAllInBatch(likesToDelete);
+            }
+        }
+
+        log.info("Likes batch processing finished for {} articles.", changedArticleIds.size());
     }
 }

--- a/src/main/java/com/grepp/teamnotfound/app/model/board/LikeBatchProcessor.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/board/LikeBatchProcessor.java
@@ -1,0 +1,82 @@
+package com.grepp.teamnotfound.app.model.board;
+
+import com.grepp.teamnotfound.app.model.board.entity.ArticleLike;
+import com.grepp.teamnotfound.app.model.board.repository.ArticleLikeRepository;
+import com.grepp.teamnotfound.app.model.board.repository.ArticleRepository;
+import com.grepp.teamnotfound.app.model.user.repository.UserRepository;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class LikeBatchProcessor {
+
+    private final RedisLikeService redisLikeService;
+    private final ArticleRepository articleRepository;
+    private final ArticleLikeRepository articleLikeRepository;
+    private final UserRepository userRepository;
+
+    // 1분마다 실행
+//    @Scheduled(fixedDelay = 60000)
+    @Scheduled(fixedDelay = 300000)
+    @Transactional
+    public void processLikeBatch() {
+
+        // NOTE 아니 모든 게시글을 가져온다고?
+        List<Long> articleIds = articleRepository.findAllArticleIds();
+
+        for (Long articleId : articleIds) {
+            Set<Object> likeRequests = redisLikeService.getLikeRequests(articleId);
+            Set<Object> unlikeRequests = redisLikeService.getUnlikeRequests(articleId);
+
+            // 좋아요 요청 처리
+            if (likeRequests != null && !likeRequests.isEmpty()) {
+                List<Long> usersToLike = likeRequests.stream()
+                    .map(object -> Long.valueOf(object.toString()))
+                    .toList();
+
+                for (Long userId : usersToLike) {
+                    // DB 에 해당 좋아요가 없는 경우만 추가
+                    if (!articleLikeRepository.existsByArticle_ArticleIdAndUser_UserId(articleId,
+                        userId)) {
+                        articleLikeRepository.save(
+                            // getReferenceById() 는 단순한 관계설정을 위한 엔티티 호출
+                            ArticleLike.builder()
+                                .article(articleRepository.getReferenceById(articleId))
+                                .user(userRepository.getReferenceById(userId))
+                                .createdAt(OffsetDateTime.now())
+                                .build()
+                        );
+                    }
+                }
+            }
+
+            // 좋아요 취소 요청 처리
+            if (unlikeRequests != null && !unlikeRequests.isEmpty()) {
+                List<Long> usersToUnlike = unlikeRequests.stream()
+                    .map(object -> Long.valueOf(object.toString()))
+                    .toList();
+
+                for (Long userId : usersToUnlike) {
+                    // DB 에 해당 좋아요가 있는 경우만 삭제
+                    articleLikeRepository
+                        .findByArticle_ArticleIdAndUser_UserId(articleId, userId)
+                        .ifPresent(articleLikeRepository::delete);
+                }
+            }
+
+            // 처리 완료된 Redis 배치 요청 데이터 비우기
+            redisLikeService.clearLikeRequests(articleId);
+        }
+
+        log.info("Likes batch processing finished");
+    }
+}

--- a/src/main/java/com/grepp/teamnotfound/app/model/board/RedisLikeService.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/board/RedisLikeService.java
@@ -1,0 +1,75 @@
+package com.grepp.teamnotfound.app.model.board;
+
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RedisLikeService {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    public void addLikeRequest(Long articleId, Long userId) {
+        String key = "article:like:" + articleId;
+        redisTemplate.opsForSet().add(key,userId);
+        redisTemplate.expire(key, 5, TimeUnit.MINUTES); // 5분 후 만료
+    }
+
+    public void addUnlikeRequest(Long articleId, Long userId) {
+        String key = "article:unlike:" + articleId;
+        redisTemplate.opsForSet().add(key, userId);
+        redisTemplate.expire(key, 5, TimeUnit.MINUTES); // 5분 후 만료
+    }
+
+    // 사용자별 특정 게시글 좋아요 상태를 Redis 에 저장
+    // 배치처리 전 DB에 다녀오지 않기 위함
+    public void setUserLikedStatus(Long articleId, Long userId, boolean liked) {
+        String userLikedKey = "user:liked_status:" + userId + ":" + articleId;
+        if (liked) {
+            redisTemplate.opsForValue().set(userLikedKey, "1");
+            redisTemplate.expire(userLikedKey, 7, TimeUnit.DAYS);
+        } else {
+            redisTemplate.delete(userLikedKey);
+        }
+    }
+
+    // 사용자가 특정 게시글을 좋아요 했는지 Redis 에서 확인
+    public boolean isUserLiked(Long articleId, Long userId) {
+        String userLikeStatusKey = "user:liked_status:" + userId + ":" + articleId;
+        return Boolean.TRUE.equals(redisTemplate.hasKey(userLikeStatusKey));
+    }
+
+    // 특정 게시글의 좋아요 요청 유저 ID 목록 (Batch 처리용)
+    public Set<Object> getLikeRequests(Long articleId) {
+        String key = "article:like:" + articleId;
+        return redisTemplate.opsForSet().members(key);
+    }
+
+    // 특정 게시글의 좋아요 취소 요청 유저 ID 목록 (Batch 처리용)
+    public Set<Object> getUnlikeRequests(Long articleId) {
+        String key = "article:unlike:" + articleId;
+        return redisTemplate.opsForSet().members(key);
+    }
+
+    // Redis 에 저장된 좋아요/취소 요청 데이터 지우기
+    public void clearLikeRequests(Long articleId) {
+        redisTemplate.delete("article:like:" + articleId);
+        redisTemplate.delete("article:unlike:" + articleId);
+    }
+
+    /**
+     *  좋아요/취소 요청이 충돌했을 때 Redis Set 에서 서로를 제거하는 메서드
+     * */
+    public void removeUnlikeRequestIfExist(Long articleId, Long userId) {
+        String unlikeKey = "article:unlike:" + articleId;
+        redisTemplate.opsForSet().remove(unlikeKey, userId);
+    }
+
+    public void removeLikeRequestIfExist(Long articleId, Long userId) {
+        String likeKey = "article:like:" + articleId;
+        redisTemplate.opsForSet().remove(likeKey, userId);
+    }
+}

--- a/src/main/java/com/grepp/teamnotfound/app/model/board/RedisLikeService.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/board/RedisLikeService.java
@@ -1,27 +1,60 @@
 package com.grepp.teamnotfound.app.model.board;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataAccessException;
+import org.springframework.data.redis.core.RedisOperations;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.SessionCallback;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class RedisLikeService {
+    // TODO Redis 가 다운되었을 경우에 대한 대비 필요
 
     private final RedisTemplate<String, Object> redisTemplate;
 
+    // 배치 대상 article
+    private static final String BATCH_ARTICLE_IDS_KEY = "batch:article:ids";
+
     public void addLikeRequest(Long articleId, Long userId) {
-        String key = "article:like:" + articleId;
-        redisTemplate.opsForSet().add(key,userId);
-        redisTemplate.expire(key, 5, TimeUnit.MINUTES); // 5분 후 만료
+        String likeKey = "article:like:" + articleId;
+        String unlikeKey = "article:unlike:" + articleId;
+
+        // 반대 요청이 이미 존재하면 제거하고 현재 요청은 무시
+        if (Boolean.TRUE.equals(redisTemplate.opsForSet().isMember(unlikeKey, userId))) {
+            redisTemplate.opsForSet().remove(unlikeKey, userId);
+            redisTemplate.opsForSet().remove(BATCH_ARTICLE_IDS_KEY, articleId);
+            return;
+        }
+        redisTemplate.opsForSet().add(likeKey,userId);
+        redisTemplate.expire(likeKey, 5, TimeUnit.MINUTES); // 5분 후 만료
+
+        // 요청 받은 article id 저장
+        redisTemplate.opsForSet().add(BATCH_ARTICLE_IDS_KEY, articleId);
     }
 
     public void addUnlikeRequest(Long articleId, Long userId) {
-        String key = "article:unlike:" + articleId;
-        redisTemplate.opsForSet().add(key, userId);
-        redisTemplate.expire(key, 5, TimeUnit.MINUTES); // 5분 후 만료
+        String likeKey = "article:like:" + articleId;
+        String unlikeKey = "article:unlike:" + articleId;
+
+        // 반대 요청이 이미 존재하면 제거하고 현재 요청은 무시
+        if (Boolean.TRUE.equals(redisTemplate.opsForSet().isMember(likeKey, userId))) {
+            redisTemplate.opsForSet().remove(likeKey, userId);
+            redisTemplate.opsForSet().remove(BATCH_ARTICLE_IDS_KEY, articleId);
+            return;
+        }
+
+        redisTemplate.opsForSet().add(unlikeKey, userId);
+        redisTemplate.expire(unlikeKey, 5, TimeUnit.MINUTES); // 5분 후 만료
+
+        // 요청 받은 article id 저장
+        redisTemplate.opsForSet().add(BATCH_ARTICLE_IDS_KEY, articleId);
     }
 
     // 사용자별 특정 게시글 좋아요 상태를 Redis 에 저장
@@ -37,7 +70,7 @@ public class RedisLikeService {
     }
 
     // 사용자가 특정 게시글을 좋아요 했는지 Redis 에서 확인
-    public boolean isUserLiked(Long articleId, Long userId) {
+    public boolean isUserLikedInRedis(Long articleId, Long userId) {
         String userLikeStatusKey = "user:liked_status:" + userId + ":" + articleId;
         return Boolean.TRUE.equals(redisTemplate.hasKey(userLikeStatusKey));
     }
@@ -54,22 +87,92 @@ public class RedisLikeService {
         return redisTemplate.opsForSet().members(key);
     }
 
-    // Redis 에 저장된 좋아요/취소 요청 데이터 지우기
-    public void clearLikeRequests(Long articleId) {
-        redisTemplate.delete("article:like:" + articleId);
-        redisTemplate.delete("article:unlike:" + articleId);
-    }
-
     /**
-     *  좋아요/취소 요청이 충돌했을 때 Redis Set 에서 서로를 제거하는 메서드
+     * Batch 처리용
+     * 트랜잭션으로 관리하기 위해 SessionCallback 사용
      * */
-    public void removeUnlikeRequestIfExist(Long articleId, Long userId) {
-        String unlikeKey = "article:unlike:" + articleId;
-        redisTemplate.opsForSet().remove(unlikeKey, userId);
+
+    // 좋아요/취소 요청을 받은 articleId 반환
+    public Set<Long> getAllChangedArticleIdsAndClear() {
+        String sourceKey = BATCH_ARTICLE_IDS_KEY;
+
+        List<Object> results = redisTemplate.execute(new SessionCallback<List<Object>>() {
+            @Override
+            public <K, V> List<Object> execute(RedisOperations<K, V> operations) throws DataAccessException {
+                operations.multi();
+
+                // Set 의 모든 멤버를 가져옴
+                Set<Object> members = ((RedisTemplate<String, Object>) operations)
+                    .opsForSet()
+                    .members(sourceKey);
+
+                // Set 을 삭제
+                ((RedisTemplate<String, Object>) operations).delete(sourceKey);
+
+                return operations.exec();
+            }
+        });
+
+        if (results != null && !results.isEmpty() && results.getFirst() instanceof Set) {
+            return ((Set<Object>) results.getFirst()).stream()
+                .map(object -> Long.valueOf(object.toString()))
+                .collect(Collectors.toSet());
+        }
+        return Collections.emptySet();
     }
 
-    public void removeLikeRequestIfExist(Long articleId, Long userId) {
-        String likeKey = "article:like:" + articleId;
-        redisTemplate.opsForSet().remove(likeKey, userId);
+    public Set<Object> getAllLikeRequestsAndClear(Long articleId) {
+        String sourceKey = "article:like:" + articleId;
+
+        // Redis 트랜잭션을 사용하여 (요청 조회 + 삭제)를 원자적으로 처리
+        List<Object> results = redisTemplate.execute(new SessionCallback<List<Object>>() {
+            @Override
+            public <K, V> List<Object> execute(RedisOperations<K, V> operations) throws DataAccessException {
+
+                operations.multi(); // 트랜잭션 시작
+
+                // 현재 Set 의 모든 멤버를 가져옴
+                Set<Object> members = ((RedisTemplate<String, Object>)operations)
+                    .opsForSet()
+                    .members(sourceKey); // Set 반환
+
+                // 현재 Set 을 삭제
+                ((RedisTemplate<String, Object>)operations).delete(sourceKey); // 삭제된 키의 개수 반환
+
+                return operations.exec(); // 트랜잭션 내의 각 명령을 순서대로 실행
+            }
+        });
+
+        // results 리스트 구조 = [Set<Object>, Long]
+        if (results != null && !results.isEmpty() && results.getFirst() instanceof Set) {
+            return (Set<Object>) results.getFirst();
+        }
+        return Collections.emptySet();
+    }
+
+    public Set<Object> getAllUnlikeRequestsAndClear(Long articleId) {
+        String sourceKey = "article:unlike:" + articleId;
+
+        List<Object> results = redisTemplate.execute(new SessionCallback<List<Object>>() {
+            @Override
+            public <K, V> List<Object> execute(RedisOperations<K, V> operations) throws DataAccessException {
+
+                operations.multi(); // 트랜잭션 시작
+
+                Set<Object> members = ((RedisTemplate<String, Object>) operations)
+                    .opsForSet()
+                    .members(sourceKey); // Set 반환
+
+                ((RedisTemplate<String, Object>) operations).delete(sourceKey); // 삭제된 키의 개수 반환
+
+                return operations.exec(); // 트랜잭션 내의 각 명령을 순서대로 실행
+            }
+        });
+
+        // results 리스트 = [Set<Object>, Long]
+        if (results != null && !results.isEmpty() && results.getFirst() instanceof Set) {
+            return (Set<Object>) results.getFirst();
+        }
+        return Collections.emptySet();
     }
 }

--- a/src/main/java/com/grepp/teamnotfound/app/model/board/repository/ArticleLikeRepository.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/board/repository/ArticleLikeRepository.java
@@ -2,6 +2,7 @@ package com.grepp.teamnotfound.app.model.board.repository;
 
 import com.grepp.teamnotfound.app.model.board.entity.Article;
 import com.grepp.teamnotfound.app.model.board.entity.ArticleLike;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -21,4 +22,10 @@ public interface ArticleLikeRepository extends JpaRepository<ArticleLike, Long> 
     Integer countByArticle_ArticleId(Long articleId);
 
     boolean existsByArticle_ArticleIdAndUser_UserId(Long article, Long userId);
+
+    @Query("SELECT al.user.userId FROM ArticleLike al WHERE al.article.articleId = :articleId")
+    List<Long> findUserIdsByArticleId(@Param("articleId") Long articleId);
+
+    @Query("SELECT al FROM ArticleLike al WHERE al.article.articleId = :articleId AND al.user.userId IN :userIds")
+    List<ArticleLike> findAllByArticleIdAndUserIds(@Param("articleId") Long articleId, @Param("userIds") List<Long> userIds);
 }

--- a/src/main/java/com/grepp/teamnotfound/app/model/board/repository/ArticleRepository.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/board/repository/ArticleRepository.java
@@ -2,6 +2,7 @@ package com.grepp.teamnotfound.app.model.board.repository;
 
 import com.grepp.teamnotfound.app.model.board.entity.Article;
 import java.time.OffsetDateTime;
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -22,4 +23,7 @@ public interface ArticleRepository extends JpaRepository<Article, Long>, Article
 
     @Query("SELECT COUNT(a) FROM Article  a WHERE a.createdAt BETWEEN :start AND :end")
     int countArticlesBetween(OffsetDateTime start, OffsetDateTime end);
+
+    @Query("SELECT a.articleId FROM Article a WHERE a.deletedAt IS NULL AND a.reportedAt IS NULL ")
+    List<Long> findAllArticleIds();
 }

--- a/src/main/java/com/grepp/teamnotfound/infra/config/SwaggerConfig.java
+++ b/src/main/java/com/grepp/teamnotfound/infra/config/SwaggerConfig.java
@@ -23,7 +23,7 @@ public class SwaggerConfig {
                         .version("v1.0.0"))
                 // todo 배포할 때만 허용...
                 .servers(List.of(
-//                        new Server().url("https://mungdiary-172598302113.asia-northeast3.run.app/")
+                        new Server().url("https://mungdiary-172598302113.asia-northeast3.run.app/")
                 ))
                 .components(
                         new Components()

--- a/src/main/java/com/grepp/teamnotfound/infra/config/SwaggerConfig.java
+++ b/src/main/java/com/grepp/teamnotfound/infra/config/SwaggerConfig.java
@@ -23,7 +23,7 @@ public class SwaggerConfig {
                         .version("v1.0.0"))
                 // todo 배포할 때만 허용...
                 .servers(List.of(
-                        new Server().url("https://mungdiary-172598302113.asia-northeast3.run.app/")
+//                        new Server().url("https://mungdiary-172598302113.asia-northeast3.run.app/")
                 ))
                 .components(
                         new Components()

--- a/src/main/java/com/grepp/teamnotfound/infra/util/requestmatcher/RequestMatcherHolder.java
+++ b/src/main/java/com/grepp/teamnotfound/infra/util/requestmatcher/RequestMatcherHolder.java
@@ -47,7 +47,7 @@ public class RequestMatcherHolder {
             // 5. 기타 개발용 open page
             // GET /**
             new RequestInfo(GET, "/", null),
-            new RequestInfo(GET, "/api/community/**", null),
+//            new RequestInfo(GET, "/api/community/**", null),
 //            new RequestInfo(GET, "/api/life-record/**", null),
 //            new RequestInfo(GET, "/api/mypage/**", null),
             new RequestInfo(GET, "/api/profile/**", null)


### PR DESCRIPTION
## ✅ PR 올리기 전에
- [x] `dev`에서 `pull` 받았나요?
- [x] `merge conflict` 발생 시, 해결하고 올리셨나요?
- [x] 자신이 작업한 `changes`만 존재하나요?
- [ ] 작업 중 DB 변경이 발생했나요?

## 🐶 구현한 기능
<img width="2064" height="1158" alt="image" src="https://github.com/user-attachments/assets/30bacfd7-2ec6-46d3-b8c9-bedf307b2f4e" />


**☑️ 요약**
- 좋아요 관련 요청 시 **Redis 에 저장 후 배치처리**로 1분마다 DB에 반영

**☑️ 주요흐름**
1. **좋아요 요청**
      - 이미 좋아요 상태인지 확인
2. **요청한 유저의 id를 Set에 저장**
      - 요청한 유저를 좋아요 상태로 저장
      - 게시글 id를 Batch 대상 Set에 저장
      - 게시글 총 좋아요 수 저장
3. **Batch Scheduler 작동해서 DB 반영** 

## 🔎 작업 내용
**✅ 좋아요/좋아요 취소 요청 필터링**
- 게시글에 대한 유저의 좋아요 상태를 보고 필터링
(이미 좋아요 상태 -> 좋아요 요청 무시)
(이미 좋아요 없는 상태 -> 좋아요 취소 요청 무시)

**✅ Batch 처리**
- Redis 의 요청을 한 번의 SQL 로 `INSERT`/`DELETE`
- 단순 반복문을 사용하면 잦은 I/O 로 Redis 의 장점 퇴색
- DB에 최종 반영된 좋아요 수로 **캐시를 업데이트하여 정합성 유지**

**✅ Redis 트랜잭션(SessionCallback) 활용**
- 배치 처리 전 좋아요 관련 요청을 가져오고 비우는 과정 존재
- (가져오기 ~ 비우기) 과정 사이에 요청이 들어오는 것을 방지
- `multi` ~ `exec` 사이의 명령들을 하나의 묶음으로 처리



