### PR TITLE
Feat : 게시글/댓글 신고 및 관리자의 신고 상세 조회, 신고 처리

### DIFF
--- a/src/main/java/com/grepp/teamnotfound/app/controller/api/admin/AdminController.java
+++ b/src/main/java/com/grepp/teamnotfound/app/controller/api/admin/AdminController.java
@@ -1,16 +1,14 @@
 package com.grepp.teamnotfound.app.controller.api.admin;
 
 import com.grepp.teamnotfound.app.controller.api.admin.code.StatsUnit;
-import com.grepp.teamnotfound.app.controller.api.admin.payload.ArticlesStatsResponse;
-import com.grepp.teamnotfound.app.controller.api.admin.payload.ReportDetailResponse;
-import com.grepp.teamnotfound.app.controller.api.admin.payload.UserCountResponse;
-import com.grepp.teamnotfound.app.controller.api.admin.payload.UserStatsResponse;
+import com.grepp.teamnotfound.app.controller.api.admin.payload.*;
 import com.grepp.teamnotfound.app.model.board.dto.MonthlyArticlesStatsDto;
 import com.grepp.teamnotfound.app.model.board.dto.YearlyArticlesStatsDto;
 import com.grepp.teamnotfound.app.model.report.ReportService;
 import com.grepp.teamnotfound.app.model.report.dto.ReportDetailDto;
 import com.grepp.teamnotfound.app.model.user.AdminService;
 import com.grepp.teamnotfound.app.model.user.dto.*;
+import com.grepp.teamnotfound.infra.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -105,6 +103,39 @@ public class AdminController {
 
         return ResponseEntity.ok(
                 ReportDetailResponse.from(dto));
+    }
+
+//    @Operation(summary = "신고 처리하기")
+//    @PatchMapping("v1/reports/result-accept")
+//    public ResponseEntity<ApiResponse<?>> acceptReport(@RequestBody AcceptReportRequest request){
+//
+//        AcceptReportDto dto = AcceptReportDto.builder()
+//                .reportId(request.getReportId())
+//                .reason(request.getAdminReason())
+//                .build();
+//
+//        AcceptReportResultDto result = adminService.acceptReport(dto);
+//        AcceptReportResponse response = AcceptReportResponse.builder()
+//                .reportId(result.getReportId())
+//                .reportState(result.getState().name())
+//                .adminReason(result.getAdminReason())
+//                .build();
+//
+//        // TODO 추가 정책 결정 시, 제재 대상자 userId, 제재 종료 날짜 반환 필요
+//        return ResponseEntity.ok(ApiResponse.success(response));
+//    }
+
+    @Operation(summary = "신고 철회하기")
+    @PatchMapping("v1/reports/result-reject")
+    public ResponseEntity<?> rejectReport(@RequestBody RejectReportRequest request){
+
+        RejectReportDto dto = RejectReportDto.builder()
+                .reportId(request.getReportId())
+                .adminReason(request.getAdminReason())
+                .build();
+
+        adminService.rejectReport(dto);
+        return ResponseEntity.ok("신고를 성공적으로 거절하였습니다.");
     }
 
 }

--- a/src/main/java/com/grepp/teamnotfound/app/controller/api/admin/AdminController.java
+++ b/src/main/java/com/grepp/teamnotfound/app/controller/api/admin/AdminController.java
@@ -105,25 +105,19 @@ public class AdminController {
                 ReportDetailResponse.from(dto));
     }
 
-//    @Operation(summary = "신고 처리하기")
-//    @PatchMapping("v1/reports/result-accept")
-//    public ResponseEntity<ApiResponse<?>> acceptReport(@RequestBody AcceptReportRequest request){
-//
-//        AcceptReportDto dto = AcceptReportDto.builder()
-//                .reportId(request.getReportId())
-//                .reason(request.getAdminReason())
-//                .build();
-//
-//        AcceptReportResultDto result = adminService.acceptReport(dto);
-//        AcceptReportResponse response = AcceptReportResponse.builder()
-//                .reportId(result.getReportId())
-//                .reportState(result.getState().name())
-//                .adminReason(result.getAdminReason())
-//                .build();
-//
-//        // TODO 추가 정책 결정 시, 제재 대상자 userId, 제재 종료 날짜 반환 필요
-//        return ResponseEntity.ok(ApiResponse.success(response));
-//    }
+    @Operation(summary = "신고 처리하기")
+    @PatchMapping("v1/reports/result-accept")
+    public ResponseEntity<?> acceptReport(@RequestBody AcceptReportRequest request){
+
+        AcceptReportDto dto = AcceptReportDto.builder()
+                .reportId(request.getReportId())
+                .adminReason(request.getAdminReason())
+                .period(request.getPeriod())
+                .build();
+
+        adminService.acceptReportAndSuspendUser(dto);
+        return ResponseEntity.ok("신고가 정상적으로 처리되었습니다.");
+    }
 
     @Operation(summary = "신고 철회하기")
     @PatchMapping("v1/reports/result-reject")

--- a/src/main/java/com/grepp/teamnotfound/app/controller/api/admin/payload/AcceptReportRequest.java
+++ b/src/main/java/com/grepp/teamnotfound/app/controller/api/admin/payload/AcceptReportRequest.java
@@ -1,0 +1,12 @@
+package com.grepp.teamnotfound.app.controller.api.admin.payload;
+
+import com.grepp.teamnotfound.app.model.user.code.SuspensionPeriod;
+import lombok.Getter;
+
+@Getter
+public class AcceptReportRequest {
+
+    private Long reportId;
+    private SuspensionPeriod period;
+    private String adminReason;
+}

--- a/src/main/java/com/grepp/teamnotfound/app/controller/api/admin/payload/RejectReportRequest.java
+++ b/src/main/java/com/grepp/teamnotfound/app/controller/api/admin/payload/RejectReportRequest.java
@@ -1,0 +1,10 @@
+package com.grepp.teamnotfound.app.controller.api.admin.payload;
+
+import lombok.Getter;
+
+@Getter
+public class RejectReportRequest {
+
+    private Long reportId;
+    private String adminReason;
+}

--- a/src/main/java/com/grepp/teamnotfound/app/controller/api/admin/payload/ReportDetailResponse.java
+++ b/src/main/java/com/grepp/teamnotfound/app/controller/api/admin/payload/ReportDetailResponse.java
@@ -13,6 +13,7 @@ public class ReportDetailResponse {
     private String type;        //board or reply
     private Long contentId;     // articleid or replyid
     private Long articleId;     // articleid
+    private String boardName;
     private String category;    // "ABUSE\" (or \"SPAM\", \"FRAUD\", \"ADULT_CONTENT\""
     private String reason;
     private String status;      //COMPLETE" (or "PENDING")
@@ -25,6 +26,7 @@ public class ReportDetailResponse {
                 .type(dto.getType())
                 .contentId(dto.getContentId())
                 .articleId(dto.getArticleId())
+                .boardName(dto.getBoardName())
                 .category(dto.getCategory())
                 .reason(dto.getReason())
                 .status(dto.getStatus())

--- a/src/main/java/com/grepp/teamnotfound/app/controller/api/admin/payload/ReportDetailResponse.java
+++ b/src/main/java/com/grepp/teamnotfound/app/controller/api/admin/payload/ReportDetailResponse.java
@@ -9,7 +9,6 @@ import lombok.Getter;
 public class ReportDetailResponse {
 
     private Long reportId;
-    private String reporter;
     private String type;        //board or reply
     private Long contentId;     // articleid or replyid
     private Long articleId;     // articleid
@@ -22,7 +21,6 @@ public class ReportDetailResponse {
     public static ReportDetailResponse from(ReportDetailDto dto) {
         return ReportDetailResponse.builder()
                 .reportId(dto.getReportId())
-                .reporter(dto.getReporter())
                 .type(dto.getType())
                 .contentId(dto.getContentId())
                 .articleId(dto.getArticleId())

--- a/src/main/java/com/grepp/teamnotfound/app/controller/api/report/ReportApiController.java
+++ b/src/main/java/com/grepp/teamnotfound/app/controller/api/report/ReportApiController.java
@@ -19,6 +19,7 @@ public class ReportApiController {
 
     private final ReportService reportService;
 
+    // TODO self report ex
     @PostMapping("/v1")
     @Operation(summary = "커뮤니티 게시글/댓글 신고")
     public ResponseEntity<?> createReport(@RequestBody ReportRequest request,
@@ -26,7 +27,7 @@ public class ReportApiController {
 
         ReportCommand command = ReportCommand.builder()
                 .reporterId(principal.getUserId())
-                .reportedId(request.getReporterId())
+//                .reportedId(request.getReportedId())
                 .reportType(request.getReportType())
                 .contentId(request.getContentId())
                 .reportCategory(request.getReportCategory())

--- a/src/main/java/com/grepp/teamnotfound/app/controller/api/report/ReportApiController.java
+++ b/src/main/java/com/grepp/teamnotfound/app/controller/api/report/ReportApiController.java
@@ -1,26 +1,39 @@
 package com.grepp.teamnotfound.app.controller.api.report;
 
 import com.grepp.teamnotfound.app.controller.api.report.payload.ReportRequest;
+import com.grepp.teamnotfound.app.model.auth.domain.Principal;
+import com.grepp.teamnotfound.app.model.report.ReportService;
+import com.grepp.teamnotfound.app.model.report.dto.ReportCommand;
+import com.grepp.teamnotfound.infra.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/community/reports")
 public class ReportApiController {
 
+    private final ReportService reportService;
+
     @PostMapping("/v1")
     @Operation(summary = "커뮤니티 게시글/댓글 신고")
-    public ResponseEntity<?> createReport(
-        @ModelAttribute ReportRequest request
-    ) {
-        return ResponseEntity.ok(Map.of("data", Map.of("msg", "신고가 정상적으로 접수되었습니다.")));
+    public ResponseEntity<?> createReport(@RequestBody ReportRequest request,
+                                          @AuthenticationPrincipal Principal principal) {
+
+        ReportCommand command = ReportCommand.builder()
+                .reporterId(principal.getUserId())
+                .reportedId(request.getReporterId())
+                .reportType(request.getReportType())
+                .contentId(request.getContentId())
+                .reportCategory(request.getReportCategory())
+                .reason(request.getReason())
+                .build();
+        Long createId = reportService.createReport(command);
+        return ResponseEntity.ok(ApiResponse.success(createId));
     }
 
 }

--- a/src/main/java/com/grepp/teamnotfound/app/controller/api/report/payload/ReportRequest.java
+++ b/src/main/java/com/grepp/teamnotfound/app/controller/api/report/payload/ReportRequest.java
@@ -9,8 +9,8 @@ public class ReportRequest {
 
     private Long reporterId;
     private Long reportedId;
-    private ReportType reportType;
+    private ReportType reportType;          // BOARD, REPLY
     private Long contentId;
-    private ReportCategory reportCategory;
+    private ReportCategory reportCategory;  // ABUSE, SPAM, FRAUD, ADULT_CONTENT
     private String reason;
 }

--- a/src/main/java/com/grepp/teamnotfound/app/controller/api/report/payload/ReportRequest.java
+++ b/src/main/java/com/grepp/teamnotfound/app/controller/api/report/payload/ReportRequest.java
@@ -7,8 +7,8 @@ import lombok.Data;
 @Data
 public class ReportRequest {
 
-    private Long reporterId;
-    private Long reportedId;
+    private Long reporterId;    // 신고한 사람(로그인 하는 사람)
+    private Long reportedId;    // 신고당하는 사람(작성자)
     private ReportType reportType;          // BOARD, REPLY
     private Long contentId;
     private ReportCategory reportCategory;  // ABUSE, SPAM, FRAUD, ADULT_CONTENT

--- a/src/main/java/com/grepp/teamnotfound/app/model/board/ArticleService.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/board/ArticleService.java
@@ -342,10 +342,6 @@ public class ArticleService {
         return articleRepository.countByArticleIdAndDeletedAtIsNullAndReportedAtIsNull(articleId);
     }
 
-    public int countArticles(OffsetDateTime monthStart, OffsetDateTime monthEnd) {
-        return articleRepository.countArticlesBetween(monthStart, monthEnd);
-    }
-
     @Transactional
     public UserProfileArticleResponse getUsersArticles(
         Long userId,

--- a/src/main/java/com/grepp/teamnotfound/app/model/board/ArticleService.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/board/ArticleService.java
@@ -346,11 +346,6 @@ public class ArticleService {
         return articleRepository.countArticlesBetween(monthStart, monthEnd);
     }
 
-    public Long getRequiredArticleIdByReplyId(Long replyId) {
-        return replyRepository.findArticleIdByReplyId(replyId)
-                .orElseThrow(()-> new BusinessException(BoardErrorCode.ARTICLE_NOT_FOUND));
-    }
-
     @Transactional
     public UserProfileArticleResponse getUsersArticles(
         Long userId,

--- a/src/main/java/com/grepp/teamnotfound/app/model/board/entity/Article.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/board/entity/Article.java
@@ -69,4 +69,8 @@ public class Article extends BaseEntity {
     @OneToMany(mappedBy = "article")
     private Set<ArticleImg> articleImgs = new HashSet<>();
 
+    public void report() {
+        this.reportedAt = OffsetDateTime.now();
+        super.updatedAt = this.reportedAt;
+    }
 }

--- a/src/main/java/com/grepp/teamnotfound/app/model/board/repository/ArticleRepository.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/board/repository/ArticleRepository.java
@@ -31,4 +31,6 @@ public interface ArticleRepository extends JpaRepository<Article, Long>, Article
 
     @Query("select a from Article a join fetch a.user where a.articleId = :articleId")
     Optional<Article> findByIdFetchUser(@Param("articleId") Long articleId);
+
+    Optional<Article> findByArticleId(Long articleId);
 }

--- a/src/main/java/com/grepp/teamnotfound/app/model/board/repository/ArticleRepository.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/board/repository/ArticleRepository.java
@@ -3,6 +3,8 @@ package com.grepp.teamnotfound.app.model.board.repository;
 import com.grepp.teamnotfound.app.model.board.entity.Article;
 import java.time.OffsetDateTime;
 import java.util.List;
+import java.util.Optional;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -26,4 +28,7 @@ public interface ArticleRepository extends JpaRepository<Article, Long>, Article
 
     @Query("SELECT a.articleId FROM Article a WHERE a.deletedAt IS NULL AND a.reportedAt IS NULL ")
     List<Long> findAllArticleIds();
+
+    @Query("select a from Article a join fetch a.user where a.articleId = :articleId")
+    Optional<Article> findByIdFetchUser(@Param("articleId") Long articleId);
 }

--- a/src/main/java/com/grepp/teamnotfound/app/model/reply/entity/Reply.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/reply/entity/Reply.java
@@ -58,4 +58,8 @@ public class Reply extends BaseEntity {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
+    public void report() {
+        this.reportedAt = OffsetDateTime.now();
+        super.updatedAt = this.reportedAt;
+    }
 }

--- a/src/main/java/com/grepp/teamnotfound/app/model/reply/repository/ReplyRepository.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/reply/repository/ReplyRepository.java
@@ -25,4 +25,7 @@ public interface ReplyRepository extends JpaRepository<Reply, Long> {
 
 
     Optional<Long> findArticleIdByReplyId(Long replyId);
+
+    @Query("select a from Reply a join fetch a.user where a.replyId = :replyId")
+    Optional<Reply> findByIdFetchUser(@Param("replyId") Long replyId);
 }

--- a/src/main/java/com/grepp/teamnotfound/app/model/reply/repository/ReplyRepository.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/reply/repository/ReplyRepository.java
@@ -1,5 +1,6 @@
 package com.grepp.teamnotfound.app.model.reply.repository;
 
+import com.grepp.teamnotfound.app.model.board.entity.Article;
 import com.grepp.teamnotfound.app.model.reply.entity.Reply;
 import java.time.OffsetDateTime;
 import org.springframework.data.domain.Page;
@@ -24,7 +25,8 @@ public interface ReplyRepository extends JpaRepository<Reply, Long> {
 
 
 
-    Optional<Long> findArticleIdByReplyId(Long replyId);
+    @Query("select r.article from Reply r where r.replyId = :replyId")
+    Optional<Article> findArticleIdByReplyId(@Param("replyId") Long replyId);
 
     @Query("select a from Reply a join fetch a.user where a.replyId = :replyId")
     Optional<Reply> findByIdFetchUser(@Param("replyId") Long replyId);

--- a/src/main/java/com/grepp/teamnotfound/app/model/reply/repository/ReplyRepository.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/reply/repository/ReplyRepository.java
@@ -29,4 +29,6 @@ public interface ReplyRepository extends JpaRepository<Reply, Long> {
 
     @Query("select a from Reply a join fetch a.user where a.replyId = :replyId")
     Optional<Reply> findByIdFetchUser(@Param("replyId") Long replyId);
+
+    Optional<Reply> findByReplyId(Long replyId);
 }

--- a/src/main/java/com/grepp/teamnotfound/app/model/reply/repository/ReplyRepository.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/reply/repository/ReplyRepository.java
@@ -4,7 +4,6 @@ import com.grepp.teamnotfound.app.model.board.entity.Article;
 import com.grepp.teamnotfound.app.model.reply.entity.Reply;
 import java.time.OffsetDateTime;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import java.util.Optional;
 
@@ -26,7 +25,7 @@ public interface ReplyRepository extends JpaRepository<Reply, Long> {
 
 
     @Query("select r.article from Reply r where r.replyId = :replyId")
-    Optional<Article> findArticleIdByReplyId(@Param("replyId") Long replyId);
+    Optional<Article> findArticleByReplyId(@Param("replyId") Long replyId);
 
     @Query("select a from Reply a join fetch a.user where a.replyId = :replyId")
     Optional<Reply> findByIdFetchUser(@Param("replyId") Long replyId);

--- a/src/main/java/com/grepp/teamnotfound/app/model/report/ReportService.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/report/ReportService.java
@@ -1,6 +1,5 @@
 package com.grepp.teamnotfound.app.model.report;
 
-import com.grepp.teamnotfound.app.model.board.ArticleService;
 import com.grepp.teamnotfound.app.model.board.entity.Article;
 import com.grepp.teamnotfound.app.model.board.repository.ArticleRepository;
 import com.grepp.teamnotfound.app.model.reply.entity.Reply;
@@ -10,7 +9,6 @@ import com.grepp.teamnotfound.app.model.report.dto.ReportCommand;
 import com.grepp.teamnotfound.app.model.report.dto.ReportDetailDto;
 import com.grepp.teamnotfound.app.model.report.entity.Report;
 import com.grepp.teamnotfound.app.model.report.repository.ReportRepository;
-import com.grepp.teamnotfound.app.model.user.UserService;
 import com.grepp.teamnotfound.app.model.user.entity.User;
 import com.grepp.teamnotfound.app.model.user.repository.UserRepository;
 import com.grepp.teamnotfound.infra.error.exception.BusinessException;
@@ -36,10 +34,10 @@ public class ReportService {
         Report report = reportRepository.findByReportId(reportId)
                 .orElseThrow(() -> new BusinessException(ReportErrorCode.REPORT_NOT_FOUND));
 
-        String reporterNickname = userRepository.findNicknameByUserId(report.getReported().getUserId());
+        String reporterNickname = userRepository.findNicknameByUserId(report.getReporter().getUserId());
 
                 Article article = (report.getType()==ReportType.REPLY) ?
-                replyRepository.findArticleIdByReplyId(report.getContentId())
+                replyRepository.findArticleByReplyId(report.getContentId())
                         .orElseThrow(()-> new BusinessException(BoardErrorCode.ARTICLE_NOT_FOUND))
                 : articleRepository.findByArticleId(report.getContentId())
                         .orElseThrow(()-> new BusinessException(BoardErrorCode.ARTICLE_NOT_FOUND));

--- a/src/main/java/com/grepp/teamnotfound/app/model/report/ReportService.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/report/ReportService.java
@@ -1,13 +1,23 @@
 package com.grepp.teamnotfound.app.model.report;
 
 import com.grepp.teamnotfound.app.model.board.ArticleService;
+import com.grepp.teamnotfound.app.model.board.entity.Article;
+import com.grepp.teamnotfound.app.model.board.repository.ArticleRepository;
+import com.grepp.teamnotfound.app.model.reply.entity.Reply;
+import com.grepp.teamnotfound.app.model.reply.repository.ReplyRepository;
 import com.grepp.teamnotfound.app.model.report.code.ReportType;
+import com.grepp.teamnotfound.app.model.report.dto.ReportCommand;
 import com.grepp.teamnotfound.app.model.report.dto.ReportDetailDto;
 import com.grepp.teamnotfound.app.model.report.entity.Report;
 import com.grepp.teamnotfound.app.model.report.repository.ReportRepository;
 import com.grepp.teamnotfound.app.model.user.UserService;
+import com.grepp.teamnotfound.app.model.user.entity.User;
+import com.grepp.teamnotfound.app.model.user.repository.UserRepository;
 import com.grepp.teamnotfound.infra.error.exception.BusinessException;
+import com.grepp.teamnotfound.infra.error.exception.code.BoardErrorCode;
+import com.grepp.teamnotfound.infra.error.exception.code.ReplyErrorCode;
 import com.grepp.teamnotfound.infra.error.exception.code.ReportErrorCode;
+import com.grepp.teamnotfound.infra.error.exception.code.UserErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,6 +27,9 @@ import org.springframework.transaction.annotation.Transactional;
 public class ReportService {
 
     private final ReportRepository reportRepository;
+    private final ArticleRepository articleRepository;
+    private final ReplyRepository replyRepository;
+    private final UserRepository userRepository;
 
     private final UserService userService;
     private final ArticleService articleService;
@@ -33,5 +46,51 @@ public class ReportService {
                 : report.getContentId();
 
         return ReportDetailDto.from(report, reporterNickname, articleId);
+    }
+
+    public Long createReport(ReportCommand command) {
+        User reporter = validateReporter(command.getReporterId());
+        User reported = findReportedUser(command.getReportType(), command.getContentId());
+
+        validateSelfReport(reporter, reported);
+        // 이미 본인이 신고한 경우 중복 신고 불가
+        validateDuplicateReport(reporter, command);
+
+        Report report = Report.of(command, reporter, reported);
+        reportRepository.save(report);
+
+        return report.getReportId();
+    }
+
+    private void validateDuplicateReport(User reporter, ReportCommand command) {
+        if (reportRepository.duplicateReport(reporter, command.getReportType(), command.getContentId())) {
+            throw new BusinessException(ReportErrorCode.DUPLICATED_REPORT);
+        }
+    }
+
+    private void validateSelfReport(User reporter, User reported) {
+        if (reporter.equals(reported)) {
+            throw new BusinessException(ReportErrorCode.CANNOT_REPORT_SELF);
+        }
+    }
+
+    private User findReportedUser(ReportType reportType, Long contentId) {
+        if(reportType==ReportType.BOARD){
+            // 게시글 존재 확인 및 작성자 갖고 오기
+            Article article = articleRepository.findByIdFetchUser(contentId)
+                    .orElseThrow(() -> new BusinessException(BoardErrorCode.ARTICLE_NOT_FOUND));
+            return article.getUser();
+
+        } else if(reportType==ReportType.REPLY){
+            Reply reply = replyRepository.findByIdFetchUser(contentId)
+                    .orElseThrow(() -> new BusinessException(ReplyErrorCode.REPLY_NOT_FOUND));
+            return reply.getUser();
+
+        } else throw new BusinessException(ReportErrorCode.REPORT_TYPE_BAD_REQUEST);
+    }
+
+    private User validateReporter(Long reporterId) {
+        return userRepository.findByUserId(reporterId)
+                .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
     }
 }

--- a/src/main/java/com/grepp/teamnotfound/app/model/report/ReportService.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/report/ReportService.java
@@ -46,11 +46,11 @@ public class ReportService {
     }
 
 
-    // TODO 중복 DB IO 정리
     public Long createReport(ReportCommand command) {
         User reporter = validateReporter(command.getReporterId());
         User reported = findReportedUser(command.getReportType(), command.getContentId());
 
+        // 스스로 신고 불가
         validateSelfReport(reporter, reported);
         // 이미 본인이 신고한 경우 중복 신고 불가
         validateDuplicateReport(reporter, command);

--- a/src/main/java/com/grepp/teamnotfound/app/model/report/code/ReportState.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/report/code/ReportState.java
@@ -1,0 +1,5 @@
+package com.grepp.teamnotfound.app.model.report.code;
+
+public enum ReportState {
+    PENDING, REJECT, ACCEPT
+}

--- a/src/main/java/com/grepp/teamnotfound/app/model/report/dto/ReportCommand.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/report/dto/ReportCommand.java
@@ -10,7 +10,7 @@ import lombok.Getter;
 public class ReportCommand {
 
     private Long reporterId;
-    private Long  reportedId;
+//    private Long  reportedId;
     private ReportType reportType;
     private Long contentId;
     private ReportCategory reportCategory;

--- a/src/main/java/com/grepp/teamnotfound/app/model/report/dto/ReportCommand.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/report/dto/ReportCommand.java
@@ -9,9 +9,9 @@ import lombok.Getter;
 @Builder
 public class ReportCommand {
 
-    private Long reporterId;
-//    private Long  reportedId;
-    private ReportType reportType;
+    private Long reporterId;        // 신고한 사람(로그인 하는 사람)
+//    private Long  reportedId;     // 신고당하는 사람(작성자)
+    private ReportType reportType;  // BOARD, REPLY
     private Long contentId;
     private ReportCategory reportCategory;
     private String reason;

--- a/src/main/java/com/grepp/teamnotfound/app/model/report/dto/ReportCommand.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/report/dto/ReportCommand.java
@@ -1,0 +1,18 @@
+package com.grepp.teamnotfound.app.model.report.dto;
+
+import com.grepp.teamnotfound.app.model.report.code.ReportCategory;
+import com.grepp.teamnotfound.app.model.report.code.ReportType;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ReportCommand {
+
+    private Long reporterId;
+    private Long  reportedId;
+    private ReportType reportType;
+    private Long contentId;
+    private ReportCategory reportCategory;
+    private String reason;
+}

--- a/src/main/java/com/grepp/teamnotfound/app/model/report/dto/ReportDetailDto.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/report/dto/ReportDetailDto.java
@@ -27,7 +27,7 @@ public class ReportDetailDto {
                 .articleId(articleId)
                 .category(report.getCategory().name())
                 .reason(report.getReason())
-                .status(report.getIsDone() ? "COMPLETE" : "PENDING")
+                .status(report.getState().name())
                 .build();
     }
 }

--- a/src/main/java/com/grepp/teamnotfound/app/model/report/dto/ReportDetailDto.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/report/dto/ReportDetailDto.java
@@ -1,5 +1,6 @@
 package com.grepp.teamnotfound.app.model.report.dto;
 
+import com.grepp.teamnotfound.app.model.board.entity.Article;
 import com.grepp.teamnotfound.app.model.report.entity.Report;
 import lombok.Builder;
 import lombok.Getter;
@@ -16,18 +17,20 @@ public class ReportDetailDto {
     private String category;    // "ABUSE" or "SPAM", "FRAUD", "ADULT_CONTENT"
     private String reason;
     private String status;
+    private String boardName;
 
 
-    public static ReportDetailDto from(Report report, String reporterNickname, Long articleId) {
+    public static ReportDetailDto from(Report report, String reporterNickname, Article article) {
         return ReportDetailDto.builder()
                 .reportId(report.getReportId())
                 .reporter(reporterNickname)
                 .type(report.getType().name())
                 .contentId(report.getContentId())
-                .articleId(articleId)
+                .articleId(article.getArticleId())
                 .category(report.getCategory().name())
                 .reason(report.getReason())
                 .status(report.getState().name())
+                .boardName(article.getBoard().getName())
                 .build();
     }
 }

--- a/src/main/java/com/grepp/teamnotfound/app/model/report/entity/Report.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/report/entity/Report.java
@@ -6,6 +6,8 @@ import com.grepp.teamnotfound.app.model.report.code.ReportType;
 import com.grepp.teamnotfound.app.model.report.dto.ReportCommand;
 import com.grepp.teamnotfound.app.model.user.entity.User;
 import com.grepp.teamnotfound.infra.entity.BaseEntity;
+import com.grepp.teamnotfound.infra.error.exception.BusinessException;
+import com.grepp.teamnotfound.infra.error.exception.code.ReportErrorCode;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -93,7 +95,21 @@ public class Report extends BaseEntity {
     }
 
     public void reject(String adminReason) {
+        if (this.state != ReportState.PENDING) {
+            throw new BusinessException(ReportErrorCode.ALREADY_COMPLETE_REPORT);
+        }
+
         this.state = ReportState.REJECT;
+        this.adminReason = adminReason;
+        super.updatedAt = OffsetDateTime.now();
+    }
+
+    public void accept(String adminReason) {
+        if (this.state != ReportState.PENDING) {
+            throw new BusinessException(ReportErrorCode.ALREADY_COMPLETE_REPORT);
+        }
+
+        this.state = ReportState.ACCEPT;
         this.adminReason = adminReason;
         super.updatedAt = OffsetDateTime.now();
     }

--- a/src/main/java/com/grepp/teamnotfound/app/model/report/entity/Report.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/report/entity/Report.java
@@ -91,5 +91,11 @@ public class Report extends BaseEntity {
                 .reported(reported)
                 .build();
     }
+
+    public void reject(String adminReason) {
+        this.state = ReportState.REJECT;
+        this.adminReason = adminReason;
+        super.updatedAt = OffsetDateTime.now();
+    }
 }
 

--- a/src/main/java/com/grepp/teamnotfound/app/model/report/entity/Report.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/report/entity/Report.java
@@ -1,7 +1,9 @@
 package com.grepp.teamnotfound.app.model.report.entity;
 
 import com.grepp.teamnotfound.app.model.report.code.ReportCategory;
+import com.grepp.teamnotfound.app.model.report.code.ReportState;
 import com.grepp.teamnotfound.app.model.report.code.ReportType;
+import com.grepp.teamnotfound.app.model.report.dto.ReportCommand;
 import com.grepp.teamnotfound.app.model.user.entity.User;
 import com.grepp.teamnotfound.infra.entity.BaseEntity;
 import jakarta.persistence.Column;
@@ -18,14 +20,17 @@ import jakarta.persistence.OneToOne;
 import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
 import java.time.OffsetDateTime;
-import lombok.Getter;
-import lombok.Setter;
+
+import lombok.*;
 
 
 @Entity
 @Table(name = "Reports")
 @Getter
 @Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Report extends BaseEntity {
 
     @Id
@@ -56,11 +61,15 @@ public class Report extends BaseEntity {
     @Column(nullable = false, columnDefinition = "text")
     private String reason;
 
-    @Column(nullable = false)
-    private OffsetDateTime reportedAt;
+    @Column
+    private OffsetDateTime reportedAt;  // 처리일
 
+    @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    private Boolean isDone;
+    private ReportState state;
+
+    @Column(columnDefinition = "text")
+    private String adminReason;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "reporter_id", nullable = false)
@@ -70,8 +79,17 @@ public class Report extends BaseEntity {
     @JoinColumn(name = "reported_id", nullable = false)
     private User reported;
 
-    @OneToOne(mappedBy = "report", fetch = FetchType.LAZY)
-    private ReportResult result;
 
+    public static Report of(ReportCommand command, User reporter, User reported) {
+        return Report.builder()
+                .type(command.getReportType())
+                .contentId(command.getContentId())
+                .category(command.getReportCategory())
+                .reason(command.getReason())
+                .state(ReportState.PENDING)
+                .reporter(reporter)
+                .reported(reported)
+                .build();
+    }
 }
 

--- a/src/main/java/com/grepp/teamnotfound/app/model/report/entity/Report.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/report/entity/Report.java
@@ -111,6 +111,7 @@ public class Report extends BaseEntity {
 
         this.state = ReportState.ACCEPT;
         this.adminReason = adminReason;
+        this.reportedAt = OffsetDateTime.now();
         super.updatedAt = OffsetDateTime.now();
     }
 }

--- a/src/main/java/com/grepp/teamnotfound/app/model/report/entity/ReportResult.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/report/entity/ReportResult.java
@@ -45,9 +45,5 @@ public class ReportResult extends BaseEntity {
     @Column(nullable = false)
     private OffsetDateTime endedAt;
 
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "report_id", nullable = false, unique = true)
-    private Report report;
-
 }
 

--- a/src/main/java/com/grepp/teamnotfound/app/model/report/repository/ReportRepository.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/report/repository/ReportRepository.java
@@ -27,9 +27,9 @@ public interface ReportRepository extends JpaRepository<Report, Long> {
     @Query("select r from Report r where r.contentId = :contentId and r.category = :category and r.state = :reportState")
     List<Report> findByContentIdAndReportCategoryAndState(@Param("contentId") Long contentId, @Param("category") ReportCategory category, @Param("reportState") ReportState reportState);
 
-    @Modifying
-    @Query("update Report r set r.state = :reportState, r.reason = :adminReason " +
+    @Modifying(flushAutomatically = true, clearAutomatically = true)
+    @Query("update Report r set r.state = :reportState, r.adminReason = :adminReason " +
             "where r.contentId = :contentId and r.category = :category and r.state = :currentState")
-    int bulkRejectPendingReports(@Param("contentId") Long contentId, @Param("category") ReportCategory category,
+    void bulkRejectPendingReports(@Param("contentId") Long contentId, @Param("category") ReportCategory category,
                                  @Param("reportState") ReportState reportState, @Param("adminReason") String adminReason, @Param("currentState") ReportState currentState);
 }

--- a/src/main/java/com/grepp/teamnotfound/app/model/report/repository/ReportRepository.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/report/repository/ReportRepository.java
@@ -1,12 +1,16 @@
 package com.grepp.teamnotfound.app.model.report.repository;
 
+import com.grepp.teamnotfound.app.model.report.code.ReportCategory;
+import com.grepp.teamnotfound.app.model.report.code.ReportState;
 import com.grepp.teamnotfound.app.model.report.code.ReportType;
 import com.grepp.teamnotfound.app.model.report.entity.Report;
 import com.grepp.teamnotfound.app.model.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface ReportRepository extends JpaRepository<Report, Long> {
@@ -19,4 +23,13 @@ public interface ReportRepository extends JpaRepository<Report, Long> {
             "and r.type = :type " +
             "and r.contentId = :contentId")
     boolean duplicateReport(@Param("reporter") User reporter, @Param("type") ReportType reportType, @Param("contentId") Long contentId);
+
+    @Query("select r from Report r where r.contentId = :contentId and r.category = :category and r.state = :reportState")
+    List<Report> findByContentIdAndReportCategoryAndState(@Param("contentId") Long contentId, @Param("category") ReportCategory category, @Param("reportState") ReportState reportState);
+
+    @Modifying
+    @Query("update Report r set r.state = :reportState, r.reason = :adminReason " +
+            "where r.contentId = :contentId and r.category = :category and r.state = :currentState")
+    int bulkRejectPendingReports(@Param("contentId") Long contentId, @Param("category") ReportCategory category,
+                                 @Param("reportState") ReportState reportState, @Param("adminReason") String adminReason, @Param("currentState") ReportState currentState);
 }

--- a/src/main/java/com/grepp/teamnotfound/app/model/report/repository/ReportRepository.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/report/repository/ReportRepository.java
@@ -1,11 +1,22 @@
 package com.grepp.teamnotfound.app.model.report.repository;
 
+import com.grepp.teamnotfound.app.model.report.code.ReportType;
 import com.grepp.teamnotfound.app.model.report.entity.Report;
+import com.grepp.teamnotfound.app.model.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface ReportRepository extends JpaRepository<Report, Long> {
 
     Optional<Report> findByReportId(Long reportId);
+
+    @Query("select count(r) > 0 " +
+            "from Report r " +
+            "where r.reporter = :reporter " +
+            "and r.type = :type " +
+            "and r.contentId = :contentId")
+    boolean duplicateReport(@Param("reporter") User reporter, @Param("type") ReportType reportType, @Param("contentId") Long contentId);
 }

--- a/src/main/java/com/grepp/teamnotfound/app/model/user/AdminService.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/user/AdminService.java
@@ -158,7 +158,7 @@ public class AdminService {
             report.reject(dto.getAdminReason());
         }
 
-        // 방법 2. 벌크 연산
+        // 방법 2. 벌크 연산 - updatedAt 추가 필요
 //        reportRepository.bulkRejectPendingReports(
 //                targetReport.getContentId(),
 //                targetReport.getCategory(),

--- a/src/main/java/com/grepp/teamnotfound/app/model/user/UserService.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/user/UserService.java
@@ -114,11 +114,6 @@ public class UserService {
         return userRepository.findByEmail(email);
     }
 
-    @Transactional(readOnly = true)
-    public String getRequiredUserNickname(Long userId) {
-        return userRepository.findNicknameByUserId(userId);
-    }
-
     @Transactional
     public UserDto updateUser(Long userId, UserWriteRequest request, List<MultipartFile> images) {
         User user = userRepository.findByUserId(userId)

--- a/src/main/java/com/grepp/teamnotfound/app/model/user/code/SuspensionPeriod.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/user/code/SuspensionPeriod.java
@@ -1,0 +1,44 @@
+package com.grepp.teamnotfound.app.model.user.code;
+
+
+import java.time.OffsetDateTime;
+import java.util.Arrays;
+
+public enum SuspensionPeriod {
+
+    ONE_DAY(1),
+    TWO_DAYS(2),
+    THREE_DAYS(3),
+    FIVE_DAYS(5),
+    SEVEN_DAYS(7),
+    FOURTEEN_DAYS(14),
+    THIRTY_DAYS(30),
+    PERMANENT(-1);      // 영구 정지
+
+    private final int days;
+
+    SuspensionPeriod(int days) {
+        this.days = days;
+    }
+
+    public int getDays() {
+        return days;
+    }
+
+    public boolean isPermanent() {
+        return this == PERMANENT;
+    }
+
+    public OffsetDateTime calculateEndTime(OffsetDateTime from) {
+        return isPermanent() ? null : from.plusDays(days);
+    }
+
+    public static SuspensionPeriod fromDays(int days) {
+        return Arrays.stream(values())
+                .filter(p -> p.days == days)
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 제재 기간입니다: " + days + "일"));
+    }
+
+
+}

--- a/src/main/java/com/grepp/teamnotfound/app/model/user/dto/AcceptReportDto.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/user/dto/AcceptReportDto.java
@@ -1,0 +1,15 @@
+package com.grepp.teamnotfound.app.model.user.dto;
+
+import com.grepp.teamnotfound.app.model.user.code.SuspensionPeriod;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class AcceptReportDto {
+
+    private Long reportId;
+    private SuspensionPeriod period;
+    private String adminReason;
+
+}

--- a/src/main/java/com/grepp/teamnotfound/app/model/user/dto/RejectReportDto.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/user/dto/RejectReportDto.java
@@ -1,0 +1,12 @@
+package com.grepp.teamnotfound.app.model.user.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class RejectReportDto {
+
+    private Long reportId;
+    private String adminReason;
+}

--- a/src/main/java/com/grepp/teamnotfound/app/model/user/entity/User.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/user/entity/User.java
@@ -1,6 +1,7 @@
 package com.grepp.teamnotfound.app.model.user.entity;
 
 import com.grepp.teamnotfound.app.model.auth.code.Role;
+import com.grepp.teamnotfound.app.model.user.code.SuspensionPeriod;
 import com.grepp.teamnotfound.infra.entity.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -14,6 +15,8 @@ import jakarta.persistence.Table;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.EnumType;
 import lombok.*;
+
+import java.time.OffsetDateTime;
 
 
 @Builder
@@ -65,4 +68,20 @@ public class User extends BaseEntity {
     @Column(length = 20)
     private String provider;
 
+    @Column
+    private OffsetDateTime suspensionEndAt;
+
+
+    public void suspend(SuspensionPeriod period) {
+        if (period.isPermanent()) {
+            this.suspensionEndAt = OffsetDateTime.MAX;
+            return;
+        }
+        OffsetDateTime now = OffsetDateTime.now();
+        if (this.suspensionEndAt == null || this.suspensionEndAt.isBefore(now)) {
+            this.suspensionEndAt = now.plusDays(period.getDays());
+        } else {
+            this.suspensionEndAt = this.suspensionEndAt.plusDays(period.getDays());
+        }
+    }
 }

--- a/src/main/java/com/grepp/teamnotfound/app/model/user/entity/User.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/user/entity/User.java
@@ -75,13 +75,16 @@ public class User extends BaseEntity {
     public void suspend(SuspensionPeriod period) {
         if (period.isPermanent()) {
             this.suspensionEndAt = OffsetDateTime.MAX;
+            super.updatedAt = OffsetDateTime.now();
             return;
         }
         OffsetDateTime now = OffsetDateTime.now();
         if (this.suspensionEndAt == null || this.suspensionEndAt.isBefore(now)) {
             this.suspensionEndAt = now.plusDays(period.getDays());
+            super.updatedAt = OffsetDateTime.now();
         } else {
             this.suspensionEndAt = this.suspensionEndAt.plusDays(period.getDays());
+            super.updatedAt = OffsetDateTime.now();
         }
     }
 }

--- a/src/main/java/com/grepp/teamnotfound/infra/entity/BaseEntity.java
+++ b/src/main/java/com/grepp/teamnotfound/infra/entity/BaseEntity.java
@@ -14,10 +14,10 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 public class BaseEntity {
 
     @Column(nullable = false)
-    private OffsetDateTime createdAt = OffsetDateTime.now();
+    protected OffsetDateTime createdAt = OffsetDateTime.now();
 
-    private OffsetDateTime updatedAt;
+    protected OffsetDateTime updatedAt;
 
-    private OffsetDateTime deletedAt;
+    protected OffsetDateTime deletedAt;
 
 }

--- a/src/main/java/com/grepp/teamnotfound/infra/error/exception/code/ReportErrorCode.java
+++ b/src/main/java/com/grepp/teamnotfound/infra/error/exception/code/ReportErrorCode.java
@@ -17,7 +17,10 @@ public enum ReportErrorCode implements BaseErrorCode{
 
     REPORT_TYPE_BAD_REQUEST(HttpStatus.BAD_REQUEST.value(), "REPORT_006", "잘못된 신고 타입입니다."),
     DUPLICATED_REPORT(HttpStatus.BAD_REQUEST.value(), "REPORT_007", "이미 신고한 콘텐츠입니다."),
-    CANNOT_REPORT_SELF(HttpStatus.BAD_REQUEST.value(), "REPORT_008", "스스로 작성한 콘텐츠는 신고할 수 없습니다.");
+    CANNOT_REPORT_SELF(HttpStatus.BAD_REQUEST.value(), "REPORT_008", "스스로 작성한 콘텐츠는 신고할 수 없습니다."),
+
+    ALREADY_COMPLETE_REPORT(HttpStatus.BAD_REQUEST.value(), "REPORT_009", "이미 처리된 신고내역입니다."),
+    ALREADY_COMPLETE_CONTENTS(HttpStatus.BAD_REQUEST.value(), "REPORT_010", "이미 신고 내역이 처리된 콘텐츠입니다.");
 
 
     private final int status;

--- a/src/main/java/com/grepp/teamnotfound/infra/error/exception/code/ReportErrorCode.java
+++ b/src/main/java/com/grepp/teamnotfound/infra/error/exception/code/ReportErrorCode.java
@@ -13,7 +13,12 @@ public enum ReportErrorCode implements BaseErrorCode{
     ALREADY_REPORTED_USER(HttpStatus.BAD_REQUEST.value(), "REPORT_003", "이미 제재된 사용자입니다."),
     REPORT_PROCESS_FAILED(HttpStatus.INTERNAL_SERVER_ERROR.value(), "REPORT_004", "제재 처리에 실패했습니다."),
 
-    REPORT_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "REPORT_005", "존재하지 않는 신고입니다.");
+    REPORT_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "REPORT_005", "존재하지 않는 신고입니다."),
+
+    REPORT_TYPE_BAD_REQUEST(HttpStatus.BAD_REQUEST.value(), "REPORT_006", "잘못된 신고 타입입니다."),
+    DUPLICATED_REPORT(HttpStatus.BAD_REQUEST.value(), "REPORT_007", "이미 신고한 콘텐츠입니다."),
+    CANNOT_REPORT_SELF(HttpStatus.BAD_REQUEST.value(), "REPORT_008", "스스로 작성한 콘텐츠는 신고할 수 없습니다.");
+
 
     private final int status;
     private final String code;


### PR DESCRIPTION
## ✅ PR 올리기 전에
- [x] `dev`에서 `pull` 받았나요?
- [x] `merge conflict` 발생 시, 해결하고 올리셨나요?
- [x] 자신이 작업한 `changes`만 존재하나요?
- [x] 작업 중 DB 변경이 발생했나요?

## 🐶 구현한 기능
- 게시글/댓글 신고
- 관리자의 신고 내역 상세 조회
- 관리자의 신고 처리(ACCEPT, REJECT)
- 서비스 -> 서비스 의존 관계 제거

## 🔎 작업 내용
- 프론트 요청으로 관리자의 신고 내역 상세 조회 반환 값에 BOARD_TYPE 추가
- 관리자의 신고 처리(ACCEPT)
    - 콘텐츠 숨김 처리(hideContentIfNot -> 해당 게시글/댓글의 reportedAt = offset.now())
    - 해당 ReportState accept 처리
        - updatedAt, reportedAt = offset.now()
        - adminReason = 입력 값
     - 동일 contentId, 동일 신고 이유, PENDING 상태 값 일괄 ACCEPT 처리
         - for 처리 : 영속성에서 관리
         - 벌크 처리 : directly 쿼리 update 
         -> 빠르지만 영속성에서 관리하지 않으며, 알림에 안 잡힐 수도 있습니다.(현재 주석 처리)
    - 사용자 제재(suspend)
        - user의 suspensionEndAt이 null이거나, 현재보다 이전일 때
        -> 현재부터 입력 받은 수만큼의 days를 더하여 suspensionEndAt 저장
        - user의 suspensionEndAt이 현재보다  이후일 때
        -> suspentionEndAt에 입력 받은 수만큼 days를 더하여 suspensionEndAt 저장
        - 입력 값이 "Permanent"일 때
        -> suspensionEndAt을 offset.MAX()
        - updatedAt = offset.now()
- 관리자의 신고 처리(REJECT)
    - 해당 ReportState reject 처리
        - updatedAt = offset.now()
        - adminReason = 입력 값
    - 동일 contentId, 동일 신고 이유, PENDING 상태 값 일괄 REJECT 처리
        - for 처리

## 📣 공유 사항
**DB 변동 사항**
- BaseEntity private 필드 -> protected
- Report
    - OffsetDateTime reportedAt : nullable (기존 : nullable=false)
    - Boolean isDone : 삭제
    - ReportState state : 신규 생성 (Enum : PENDING, REJECT, ACCEPT)
    - String adminReason : 신규 생성(nullable)
    - ReportResult result : `@OneToOne` 관계 제거 및 필드 삭제
- ReportResult
    - Report report : `@OneToOne` 관계 제거 및 필드 삭제
    - 큐 클래스 이슈가 떠서 엔티티자체를 삭제하진 못하고, 두 엔티티에서 연관 관계 및 관련 필드만 지웠습니다.
- User
    - OffsetDateTime suspensionEndAt : 신규 생성(nullable)
 
**※ DB 변동에 따른 더미데이터 수정은 배포 적용 직전에 작업할 수 있도록 기존 더미데이터와 구분되게 작성해 놓겠습니다.**