### PR TITLE
Fix: 생활기록 조회할 때 시간이 -9 되는 문제 수정

### DIFF
--- a/src/main/java/com/grepp/teamnotfound/app/model/life_record/LifeRecordService.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/life_record/LifeRecordService.java
@@ -20,6 +20,7 @@ import com.grepp.teamnotfound.infra.error.exception.code.LifeRecordErrorCode;
 import com.grepp.teamnotfound.infra.error.exception.code.PetErrorCode;
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
+import java.time.ZoneId;
 import java.util.*;
 
 import lombok.RequiredArgsConstructor;
@@ -73,18 +74,20 @@ public class LifeRecordService {
     // 생활기록 조회
     @Transactional(readOnly = true)
     public LifeRecordData getLifeRecord(Long lifeRecordId){
+        ZoneId seoulZoneId = ZoneId.of("Asia/Seoul");
+
         LifeRecord lifeRecord = lifeRecordRepository.findByLifeRecordId(lifeRecordId)
                 .orElseThrow(() -> new LifeRecordException(LifeRecordErrorCode.LIFERECORD_NOT_FOUND));
 
         List<WalkingData> walkingList = lifeRecord.getWalkingList().stream()
                 .map(walking -> WalkingData.builder()
-                        .startTime(walking.getStartTime().toLocalDateTime())
-                        .endTime(walking.getEndTime().toLocalDateTime())
+                        .startTime(walking.getStartTime().atZoneSameInstant(seoulZoneId).toLocalDateTime())
+                        .endTime(walking.getEndTime().atZoneSameInstant(seoulZoneId).toLocalDateTime())
                         .pace(walking.getPace())
                         .build()).toList();
         List<FeedingData> feedingList = lifeRecord.getFeedingList().stream()
                 .map(feeding -> FeedingData.builder()
-                        .mealtime(feeding.getMealTime().toLocalDateTime())
+                        .mealtime(feeding.getMealTime().atZoneSameInstant(seoulZoneId).toLocalDateTime())
                         .amount(feeding.getAmount())
                         .unit(feeding.getUnit())
                         .build()).toList();


### PR DESCRIPTION
## ✅ PR 올리기 전에
- [x] `dev`에서 `pull` 받았나요?
- [x] `merge conflict` 발생 시, 해결하고 올리셨나요?
- [x] 자신이 작업한 `changes`만 존재하나요?
- [ ] 작업 중 DB 변경이 발생했나요?

## 🔎 작업 내용
생활기록 조회할 때 시간이 -9 되는 문제 수정