### PR TITLE
생활기록 데이터에 따른 펫 몸무게 업데이트(매일 00:05에 배치 스케줄링 실행)

### DIFF
--- a/src/main/java/com/grepp/teamnotfound/app/model/life_record/WeightBatchScheduler.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/life_record/WeightBatchScheduler.java
@@ -1,0 +1,37 @@
+package com.grepp.teamnotfound.app.model.life_record;
+
+import com.grepp.teamnotfound.app.model.life_record.entity.LifeRecord;
+import com.grepp.teamnotfound.app.model.life_record.repository.LifeRecordRepository;
+import com.grepp.teamnotfound.app.model.pet.entity.Pet;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class WeightBatchScheduler {
+
+    private final LifeRecordRepository lifeRecordRepository;
+
+    @Scheduled(cron = "0 5 0 * * *") // 매일 00:05
+    @Transactional
+    public void updatePetWeightFromLifeRecords() {
+        LocalDate today = LocalDate.now();
+        List<LifeRecord> lifeRecords = lifeRecordRepository.findToday(today);
+
+        for (LifeRecord lifeRecord : lifeRecords) {
+            if (lifeRecord.getWeight() != null) {
+                Pet pet = lifeRecord.getPet();
+                pet.setWeight(lifeRecord.getWeight());
+            }
+        }
+
+        log.info("펫 몸무게 {}건 업데이트 완료", lifeRecords.size());
+
+    }
+}

--- a/src/main/java/com/grepp/teamnotfound/app/model/life_record/repository/LifeRecordRepository.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/life_record/repository/LifeRecordRepository.java
@@ -1,12 +1,10 @@
 package com.grepp.teamnotfound.app.model.life_record.repository;
 
-import com.grepp.teamnotfound.app.controller.api.life_record.payload.LifeRecordData;
 import com.grepp.teamnotfound.app.model.life_record.entity.LifeRecord;
+import com.grepp.teamnotfound.app.model.pet.entity.Pet;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
-
-import com.grepp.teamnotfound.app.model.pet.entity.Pet;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -26,4 +24,7 @@ public interface LifeRecordRepository extends JpaRepository<LifeRecord, Long>, L
     List<LifeRecord> findTop10ByPetAndDeletedAtNullAndRecordedAtBeforeAndWeightIsNotNullOrderByRecordedAtDesc(Pet pet, LocalDate date);
 
     List<LifeRecord> findByPetAndDeletedAtNullAndRecordedAtBetweenOrderByRecordedAtDesc(Pet pet, LocalDate date, LocalDate localDate);
+
+    @Query("SELECT l FROM LifeRecord l WHERE l.recordedAt = :today AND l.deletedAt IS NULL")
+    List<LifeRecord> findToday(LocalDate today);
 }


### PR DESCRIPTION
## ✅ PR 올리기 전에
- [x] `dev`에서 `pull` 받았나요?
- [x] `merge conflict` 발생 시, 해결하고 올리셨나요?
- [x] 자신이 작업한 `changes`만 존재하나요?
- [ ] 작업 중 DB 변경이 발생했나요?

## 🐶 구현한 기능
생활기록 데이터에 따른 펫 몸무게 업데이트(매일 00:05에 배치 스케줄링 실행)

## 🔎 작업 내용
생활기록 CRUD 작업마다 몸무게 업데이트를 하면 부하가 클 것 같아서 배치 스케줄링 기법을 도입했습니다.
우선 매일 00:05에 배치 스케줄링을 실행하게 했는데, 반려견마다 맞춤형 제안이 오는 시간 직전에 몸무게 업데이트를 해줘도 좋을 것 같습니다.
(언제가 좋을지 말씀해주시면 반영하겠습니다!)

## 📣 공유 사항

