### PR TITLE
Feat : 프론트 요청에 따른 신고 상세 내역 조회 응답 값 추가 및 리팩토링

### DIFF
--- a/src/main/java/com/grepp/teamnotfound/app/controller/api/admin/AdminController.java
+++ b/src/main/java/com/grepp/teamnotfound/app/controller/api/admin/AdminController.java
@@ -119,11 +119,8 @@ public class AdminController {
     @Operation(summary = "신고내역 상세 보기")
     @GetMapping("v1/reports/{reportId}")
     public ResponseEntity<ReportDetailResponse> getReportDetail(@PathVariable Long reportId) {
-
         ReportDetailDto dto = reportService.getReportDetail(reportId);
-
-        return ResponseEntity.ok(
-                ReportDetailResponse.from(dto));
+        return ResponseEntity.ok(ReportDetailResponse.from(dto));
     }
 
     @Operation(summary = "신고 처리하기")

--- a/src/main/java/com/grepp/teamnotfound/app/controller/api/admin/payload/ReportDetailResponse.java
+++ b/src/main/java/com/grepp/teamnotfound/app/controller/api/admin/payload/ReportDetailResponse.java
@@ -9,25 +9,32 @@ import lombok.Getter;
 public class ReportDetailResponse {
 
     private Long reportId;
-    private String type;        //board or reply
+    private String type;        // board or reply
     private Long contentId;     // articleid or replyid
     private Long articleId;     // articleid
-    private String boardName;
+    private String boardType;   // free, qna
     private String category;    // "ABUSE\" (or \"SPAM\", \"FRAUD\", \"ADULT_CONTENT\""
     private String reason;
-    private String status;      //COMPLETE" (or "PENDING")
-
+    private String status;      // pending, reject, accept
+    private String reporterNickname;
+    private String reportedNickname;
+    private String adminReason;
+    private String reportedState;   // active, suspended, leave
 
     public static ReportDetailResponse from(ReportDetailDto dto) {
         return ReportDetailResponse.builder()
                 .reportId(dto.getReportId())
-                .type(dto.getType())
+                .type(dto.getType().name())
                 .contentId(dto.getContentId())
                 .articleId(dto.getArticleId())
-                .boardName(dto.getBoardName())
-                .category(dto.getCategory())
+                .boardType(dto.getBoardType())
+                .category(dto.getCategory().name())
                 .reason(dto.getReason())
-                .status(dto.getStatus())
+                .status(dto.getStatus().name())
+                .reporterNickname(dto.getReporterNickname())
+                .reportedNickname(dto.getReportedNickname())
+                .adminReason(dto.getAdminReason())
+                .reportedState(dto.getReportedState().name())
                 .build();
     }
 }

--- a/src/main/java/com/grepp/teamnotfound/app/model/board/repository/ArticleRepository.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/board/repository/ArticleRepository.java
@@ -1,6 +1,7 @@
 package com.grepp.teamnotfound.app.model.board.repository;
 
 import com.grepp.teamnotfound.app.model.board.entity.Article;
+
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -33,4 +34,12 @@ public interface ArticleRepository extends JpaRepository<Article, Long>, Article
     Optional<Article> findByIdFetchUser(@Param("articleId") Long articleId);
 
     Optional<Article> findByArticleId(Long articleId);
+
+    @Query("""
+            select a
+            from Article a
+            join fetch a.board
+            where a.articleId = :articleId
+            """)
+    Optional<Article> findWithBoardByArticleId(@Param("articleId") Long articleId);
 }

--- a/src/main/java/com/grepp/teamnotfound/app/model/reply/repository/ReplyRepository.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/reply/repository/ReplyRepository.java
@@ -2,9 +2,12 @@ package com.grepp.teamnotfound.app.model.reply.repository;
 
 import com.grepp.teamnotfound.app.model.board.entity.Article;
 import com.grepp.teamnotfound.app.model.reply.entity.Reply;
+
 import java.time.OffsetDateTime;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -23,9 +26,16 @@ public interface ReplyRepository extends JpaRepository<Reply, Long> {
     Page<Reply> findByArticle_ArticleIdAndDeletedAtIsNullAndReportedAtIsNull(Long articleId, Pageable pageable);
 
 
-
     @Query("select r.article from Reply r where r.replyId = :replyId")
     Optional<Article> findArticleByReplyId(@Param("replyId") Long replyId);
+
+    @Query("""
+            select a
+            from Reply r
+            join r.article a
+            join fetch a.board
+            where r.replyId = :replyId""")
+    Optional<Article> findArticleWithBoardByReplyId(@Param("replyId") Long replyId);
 
     @Query("select a from Reply a join fetch a.user where a.replyId = :replyId")
     Optional<Reply> findByIdFetchUser(@Param("replyId") Long replyId);

--- a/src/main/java/com/grepp/teamnotfound/app/model/report/ReportService.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/report/ReportService.java
@@ -34,15 +34,13 @@ public class ReportService {
         Report report = reportRepository.findByReportId(reportId)
                 .orElseThrow(() -> new BusinessException(ReportErrorCode.REPORT_NOT_FOUND));
 
-        String reporterNickname = userRepository.findNicknameByUserId(report.getReporter().getUserId());
-
-                Article article = (report.getType()==ReportType.REPLY) ?
+        Article article = (report.getType() == ReportType.REPLY) ?
                 replyRepository.findArticleByReplyId(report.getContentId())
-                        .orElseThrow(()-> new BusinessException(BoardErrorCode.ARTICLE_NOT_FOUND))
+                        .orElseThrow(() -> new BusinessException(BoardErrorCode.ARTICLE_NOT_FOUND))
                 : articleRepository.findByArticleId(report.getContentId())
-                        .orElseThrow(()-> new BusinessException(BoardErrorCode.ARTICLE_NOT_FOUND));
+                .orElseThrow(() -> new BusinessException(BoardErrorCode.ARTICLE_NOT_FOUND));
 
-        return ReportDetailDto.from(report, reporterNickname, article);
+        return ReportDetailDto.from(report, article);
     }
 
 
@@ -74,13 +72,13 @@ public class ReportService {
     }
 
     private User findReportedUser(ReportType reportType, Long contentId) {
-        if(reportType==ReportType.BOARD){
+        if (reportType == ReportType.BOARD) {
             // 게시글 존재 확인 및 작성자 갖고 오기
             Article article = articleRepository.findByIdFetchUser(contentId)
                     .orElseThrow(() -> new BusinessException(BoardErrorCode.ARTICLE_NOT_FOUND));
             return article.getUser();
 
-        } else if(reportType==ReportType.REPLY){
+        } else if (reportType == ReportType.REPLY) {
             Reply reply = replyRepository.findByIdFetchUser(contentId)
                     .orElseThrow(() -> new BusinessException(ReplyErrorCode.REPLY_NOT_FOUND));
             return reply.getUser();

--- a/src/main/java/com/grepp/teamnotfound/app/model/report/ReportService.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/report/ReportService.java
@@ -31,13 +31,14 @@ public class ReportService {
 
     @Transactional(readOnly = true)
     public ReportDetailDto getReportDetail(Long reportId) {
-        Report report = reportRepository.findByReportId(reportId)
+
+        Report report = reportRepository.findByReportIdWithUsers(reportId)
                 .orElseThrow(() -> new BusinessException(ReportErrorCode.REPORT_NOT_FOUND));
 
         Article article = (report.getType() == ReportType.REPLY) ?
-                replyRepository.findArticleByReplyId(report.getContentId())
+                replyRepository.findArticleWithBoardByReplyId(report.getContentId())
                         .orElseThrow(() -> new BusinessException(BoardErrorCode.ARTICLE_NOT_FOUND))
-                : articleRepository.findByArticleId(report.getContentId())
+                : articleRepository.findWithBoardByArticleId(report.getContentId())
                 .orElseThrow(() -> new BusinessException(BoardErrorCode.ARTICLE_NOT_FOUND));
 
         return ReportDetailDto.from(report, article);

--- a/src/main/java/com/grepp/teamnotfound/app/model/report/dto/ReportDetailDto.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/report/dto/ReportDetailDto.java
@@ -1,7 +1,11 @@
 package com.grepp.teamnotfound.app.model.report.dto;
 
 import com.grepp.teamnotfound.app.model.board.entity.Article;
+import com.grepp.teamnotfound.app.model.report.code.ReportCategory;
+import com.grepp.teamnotfound.app.model.report.code.ReportState;
+import com.grepp.teamnotfound.app.model.report.code.ReportType;
 import com.grepp.teamnotfound.app.model.report.entity.Report;
+import com.grepp.teamnotfound.app.model.user.code.UserStateResponse;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -10,27 +14,33 @@ import lombok.Getter;
 public class ReportDetailDto {
 
     private Long reportId;
-    private String reporter;    //신고자 닉네임
-    private String type;        //board or reply
+    private ReportType type;        // board or reply
     private Long contentId;     // articleId or replyId
     private Long articleId;     // articleId or type이 reply일 때 해당 reply의 articleId
-    private String category;    // "ABUSE" or "SPAM", "FRAUD", "ADULT_CONTENT"
+    private ReportCategory category;    // "ABUSE" or "SPAM", "FRAUD", "ADULT_CONTENT"
     private String reason;
-    private String status;
-    private String boardName;
+    private ReportState status;      // pending, accept, reject
+    private String boardType;
+    private String reporterNickname;
+    private String reportedNickname;
+    private String adminReason;
+    private UserStateResponse reportedState;
 
 
-    public static ReportDetailDto from(Report report, String reporterNickname, Article article) {
+    public static ReportDetailDto from(Report report, Article article) {
         return ReportDetailDto.builder()
                 .reportId(report.getReportId())
-                .reporter(reporterNickname)
-                .type(report.getType().name())
+                .type(report.getType())
                 .contentId(report.getContentId())
                 .articleId(article.getArticleId())
-                .category(report.getCategory().name())
+                .category(report.getCategory())
                 .reason(report.getReason())
-                .status(report.getState().name())
-                .boardName(article.getBoard().getName())
+                .status(report.getState())
+                .boardType(article.getBoard().getName())
+                .reporterNickname(report.getReporter().getNickname())
+                .reportedNickname(report.getReported().getNickname())
+                .adminReason(report.getAdminReason())
+                .reportedState(report.getReported().getUserState())
                 .build();
     }
 }

--- a/src/main/java/com/grepp/teamnotfound/app/model/report/repository/ReportRepository.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/report/repository/ReportRepository.java
@@ -15,8 +15,6 @@ import java.util.Optional;
 
 public interface ReportRepository extends JpaRepository<Report, Long>, ReportRepositoryCustom {
 
-    Optional<Report> findByReportId(Long reportId);
-
     @Query("select count(r) > 0 " +
             "from Report r " +
             "where r.reporter = :reporter " +
@@ -32,4 +30,11 @@ public interface ReportRepository extends JpaRepository<Report, Long>, ReportRep
             "where r.contentId = :contentId and r.category = :category and r.state = :currentState")
     void bulkRejectPendingReports(@Param("contentId") Long contentId, @Param("category") ReportCategory category,
                                  @Param("reportState") ReportState reportState, @Param("adminReason") String adminReason, @Param("currentState") ReportState currentState);
+
+    @Query ("select r " +
+            "from Report r " +
+            "join fetch r.reporter " +
+            "join fetch r.reported " +
+            "where r.reportId = :reportId")
+    Optional<Report> findByReportIdWithUsers(@Param("reportId") Long reportId);
 }

--- a/src/main/java/com/grepp/teamnotfound/app/model/user/code/UserStateResponse.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/user/code/UserStateResponse.java
@@ -2,6 +2,6 @@ package com.grepp.teamnotfound.app.model.user.code;
 
 public enum UserStateResponse {
     ACTIVE, // 활성
-    INACTIVE, // 제재
+    SUSPENDED, // 제재
     LEAVE; // 탈퇴
 }

--- a/src/main/java/com/grepp/teamnotfound/app/model/user/entity/User.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/user/entity/User.java
@@ -2,6 +2,7 @@ package com.grepp.teamnotfound.app.model.user.entity;
 
 import com.grepp.teamnotfound.app.model.auth.code.Role;
 import com.grepp.teamnotfound.app.model.user.code.SuspensionPeriod;
+import com.grepp.teamnotfound.app.model.user.code.UserStateResponse;
 import com.grepp.teamnotfound.infra.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
@@ -77,4 +78,13 @@ public class User extends BaseEntity {
             super.updatedAt = OffsetDateTime.now();
         }
     }
-}
+
+    public UserStateResponse getUserState() {
+        if (this.deletedAt != null) {
+            return UserStateResponse.LEAVE;
+        } else if(this.suspensionEndAt == null || this.suspensionEndAt.isBefore(OffsetDateTime.now())){
+            return UserStateResponse.ACTIVE;
+        } else
+            return UserStateResponse.SUSPENDED;
+        }
+    }

--- a/src/test/java/com/grepp/teamnotfound/app/model/report/ReportServiceTest.java
+++ b/src/test/java/com/grepp/teamnotfound/app/model/report/ReportServiceTest.java
@@ -1,0 +1,220 @@
+package com.grepp.teamnotfound.app.model.report;
+
+import com.grepp.teamnotfound.app.model.board.entity.Article;
+import com.grepp.teamnotfound.app.model.board.entity.Board;
+import com.grepp.teamnotfound.app.model.board.repository.ArticleRepository;
+import com.grepp.teamnotfound.app.model.reply.entity.Reply;
+import com.grepp.teamnotfound.app.model.reply.repository.ReplyRepository;
+import com.grepp.teamnotfound.app.model.report.code.ReportType;
+import com.grepp.teamnotfound.app.model.report.dto.ReportDetailDto;
+import com.grepp.teamnotfound.app.model.report.entity.Report;
+import com.grepp.teamnotfound.app.model.report.repository.ReportRepository;
+import com.grepp.teamnotfound.app.model.user.code.UserStateResponse;
+import com.grepp.teamnotfound.app.model.user.entity.User;
+import com.grepp.teamnotfound.infra.error.exception.BusinessException;
+import com.grepp.teamnotfound.infra.error.exception.code.BoardErrorCode;
+import com.grepp.teamnotfound.infra.error.exception.code.ReportErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.OffsetDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ReportServiceTest {
+
+    @InjectMocks
+    private ReportService reportService;
+
+    @Mock
+    private ReportRepository reportRepository;
+    @Mock
+    private ArticleRepository articleRepository;
+    @Mock
+    private ReplyRepository replyRepository;
+
+    // 공통 객체
+    private User reporter;
+    private User reported;
+    private Board board;
+    private Article article;
+    private Reply reply;
+
+    @BeforeEach
+    void setUp() {
+        reporter = User.builder()
+                .userId(1L)
+                .nickname("신고자")
+                .build();
+        reported = User.builder()
+                .userId(2L)
+                .nickname("피신고자")
+                .build();
+        board = Board.builder()
+                .boardId(1L)
+                .name("자유게시판")
+                .build();
+        article = Article.builder()
+                .articleId(10L)
+                .title("테스트 게시글")
+                .board(board)
+                .build();
+        reply = Reply.builder()
+                .replyId(1L)
+                .content("테스트 댓글")
+                .article(article)
+                .build();
+    }
+
+    @Test
+    @DisplayName("성공 - 게시글 신고 상세 조회/fetch 진행 여부")
+    void getReportDetail_forBoard_success() {
+        // given
+        Long reportId = 1L;
+        Long contentId = article.getArticleId();
+        Report boardReport = Report.builder()
+                .reportId(reportId)
+                .reporter(reporter)
+                .reported(reported)
+                .type(ReportType.BOARD)
+                .contentId(contentId)
+                .build();
+
+        // report 존재 검증
+        when(reportRepository.findByReportIdWithUsers(reportId))
+                .thenReturn(Optional.of(boardReport));
+        // 신고된 article 존재 검증
+        when(articleRepository.findWithBoardByArticleId(contentId))
+                .thenReturn(Optional.of(article));
+
+        // when
+        ReportDetailDto result = reportService.getReportDetail(reportId);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getReportId()).isEqualTo(reportId);
+        assertThat(result.getContentId()).isEqualTo(contentId);
+        assertThat(result.getArticleId()).isEqualTo(article.getArticleId());
+        assertThat(result.getBoardType()).isEqualTo(board.getName());
+        assertThat(result.getReporterNickname()).isEqualTo(reporter.getNickname());
+        assertThat(result.getReportedNickname()).isEqualTo(reported.getNickname());
+        assertThat(result.getReportedState()).isEqualTo(reported.getUserState());
+        assertThat(result.getReportedState()).isEqualTo(UserStateResponse.ACTIVE);
+
+        // replyRepository의 메소드는 호출되지 않았는지
+        verify(replyRepository, never()).findArticleWithBoardByReplyId(anyLong());
+    }
+
+    @Test
+    @DisplayName("성공 - 댓글 신고 상세 조회/fetch 진행 여부")
+    void getReportDetail_forReply_success() {
+        // given
+        Long reportId = 2L;
+        Long contentId = 20L;       // reply id
+        Report replyReport = Report.builder()
+                .reportId(reportId)
+                .reporter(reporter)
+                .reported(reported)
+                .type(ReportType.REPLY)
+                .contentId(contentId)
+                .build();
+
+        when(reportRepository.findByReportIdWithUsers(reportId))
+                .thenReturn(Optional.of(replyReport));
+        when(replyRepository.findArticleWithBoardByReplyId(contentId))
+                .thenReturn(Optional.of(article));
+
+        // when
+        ReportDetailDto result = reportService.getReportDetail(reportId);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getType()).isEqualTo(replyReport.getType());
+        assertThat(result.getBoardType()).isEqualTo(board.getName());
+
+        verify(articleRepository, never()).findWithBoardByArticleId(anyLong());
+    }
+
+    @Test
+    @DisplayName("실패 - report not found")
+    void getReportDetail_reportNotFound() {
+        // given
+        Long reportId = 999L;
+        when(reportRepository.findByReportIdWithUsers(reportId))
+                .thenReturn(Optional.empty());
+
+        // when then
+        BusinessException exception = assertThrows(BusinessException.class, () -> {
+            reportService.getReportDetail(reportId);
+        });
+
+        assertThat(exception.getErrorCode()).isEqualTo(ReportErrorCode.REPORT_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("실패 - article not found - BOARD")
+    void getReportDetail_forBoard_articleNotFound() {
+        // given
+        Long reportId = 1L;
+        Long contentId = article.getArticleId();
+        Report boardReport = Report.builder()
+                .reportId(reportId)
+                .reporter(reporter)
+                .reported(reported)
+                .type(ReportType.BOARD)
+                .contentId(contentId)
+                .build();
+
+        when(reportRepository.findByReportIdWithUsers(reportId))
+                .thenReturn(Optional.of(boardReport));
+        when(articleRepository.findWithBoardByArticleId(contentId))
+                .thenReturn(Optional.empty());
+
+        // when
+        BusinessException exception = assertThrows(BusinessException.class, () -> {
+            reportService.getReportDetail(reportId);
+        });
+
+        assertThat(exception.getErrorCode()).isEqualTo(BoardErrorCode.ARTICLE_NOT_FOUND);
+        verify(replyRepository, never()).findArticleWithBoardByReplyId(anyLong());
+    }
+
+    @Test
+    @DisplayName("실패 - article not found - REPLY")
+    void getReportDetail_forReply_articleNotFound() {
+        // given
+        Long reportId = 1L;
+        Long contentId = article.getArticleId();
+        Report replyReport = Report.builder()
+                .reportId(reportId)
+                .reporter(reporter)
+                .reported(reported)
+                .type(ReportType.REPLY)
+                .contentId(contentId)
+                .build();
+
+        when(reportRepository.findByReportIdWithUsers(reportId))
+                .thenReturn(Optional.of(replyReport));
+        when(replyRepository.findArticleWithBoardByReplyId(contentId))
+                .thenReturn(Optional.empty());
+
+        // when
+        BusinessException exception = assertThrows(BusinessException.class, () -> {
+            reportService.getReportDetail(reportId);
+        });
+
+        assertThat(exception.getErrorCode()).isEqualTo(BoardErrorCode.ARTICLE_NOT_FOUND);
+        verify(articleRepository, never()).findWithBoardByArticleId(anyLong());
+    }
+
+}

--- a/src/test/java/com/grepp/teamnotfound/app/model/report/ReportServiceTest.java
+++ b/src/test/java/com/grepp/teamnotfound/app/model/report/ReportServiceTest.java
@@ -217,4 +217,36 @@ class ReportServiceTest {
         verify(articleRepository, never()).findWithBoardByArticleId(anyLong());
     }
 
+    @Test
+    @DisplayName("성공 - 대상자가 탈퇴일 때 해당 UserState = LEAVE")
+    void getReportDetail_whenReportedUserIsLeave() {
+        // given
+        User reportedLeaveUser = User.builder()
+                .userId(1L)
+                .nickname("탈퇴한대상자")
+                .build();
+        reportedLeaveUser.setDeletedAt(OffsetDateTime.now().minusDays(1));
+
+        Long reportId = 1L;
+        Long contentId = article.getArticleId();
+        Report report = Report.builder()
+                .reportId(reportId)
+                .reporter(reporter)
+                .reported(reportedLeaveUser)
+                .type(ReportType.BOARD)
+                .contentId(contentId)
+                .build();
+
+
+        when(reportRepository.findByReportIdWithUsers(reportId))
+                .thenReturn(Optional.of(report));
+        when(articleRepository.findWithBoardByArticleId(contentId))
+                .thenReturn(Optional.of(article));
+
+        // when
+        ReportDetailDto result = reportService.getReportDetail(reportId);
+
+        // then
+        assertThat(result.getReportedState()).isEqualTo(UserStateResponse.LEAVE);
+    }
 }

--- a/src/test/java/com/grepp/teamnotfound/app/model/user/entity/UserTest.java
+++ b/src/test/java/com/grepp/teamnotfound/app/model/user/entity/UserTest.java
@@ -1,0 +1,66 @@
+package com.grepp.teamnotfound.app.model.user.entity;
+
+import com.grepp.teamnotfound.app.model.user.code.UserStateResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.OffsetDateTime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class UserTest {
+
+    @Test
+    @DisplayName("deletedAt에 값이 있는 유저는 LEAVE 반환")
+    void getUserState_DeletedUser_ReturnLeave() {
+        // given
+        User user = new User();
+        user.setDeletedAt(OffsetDateTime.now());
+
+        // when
+        UserStateResponse state = user.getUserState();
+
+        // then
+        assertEquals(UserStateResponse.LEAVE, state);
+    }
+
+
+    @Test
+    @DisplayName("suspendedAt에 오늘 이후의 값이 있으면 SUSPENSION 반환")
+    void getUserState_SuspendedUser_ReturnSuspendedUser() {
+        User user = User.builder()
+                .suspensionEndAt(OffsetDateTime.now().plusDays(3))
+                .build();
+
+        // when
+        UserStateResponse state = user.getUserState();
+
+        //then
+        assertEquals(UserStateResponse.SUSPENDED, state);
+    }
+
+
+    @Test
+    @DisplayName("suspendedAt에 오늘 이전의 값이 있고, deletedAt이 null이면 ACTIVE 반환")
+    void getUserState_ActiveUser_ReturnSuspendedUser() {
+        User user = User.builder()
+                .suspensionEndAt(OffsetDateTime.now().minusDays(3))
+                .build();
+
+        // when
+        UserStateResponse state = user.getUserState();
+
+        // then
+        assertEquals(UserStateResponse.ACTIVE, state);
+    }
+
+    @Test
+    @DisplayName("suspendedAt, deletedAt이 모두 null이면 ACTIVE 반환")
+    void getUserState_ActiveUser_ReturnNullUser() {
+        User user = new User();
+
+        UserStateResponse state = user.getUserState();
+
+        assertEquals(UserStateResponse.ACTIVE, state);
+    }
+}


### PR DESCRIPTION
## ✅ PR 올리기 전에
- [x] `dev`에서 `pull` 받았나요?
- [x] `merge conflict` 발생 시, 해결하고 올리셨나요?
- [x] 자신이 작업한 `changes`만 존재하나요?
- [ ] 작업 중 DB 변경이 발생했나요?

## 🐶 구현한 기능
- 신고 상세 내역 조회 응답 값으로 추가 요청한 건에 대해 구현했습니다.
    - 관리자의 사유(미입력 시, null)
    - 신고자/신고 대상자 닉네임
    - 신고 대상자 회원 상태
    - 신고의 처리 상태
- 추가 요청 필드 작업하면서 소소하게 리팩토링 했습니다.
    - 유저 회원 상태 get메서드 제작
    -> `user.getUserState` 이런 식으로 작성하면 해당 user의 deletedAt, suspensionEndDate 에 따라
    active, leave, suspended 등 적절한 Enum 값을 반환합니다.
    (근데 사실.. state 필드를 만들어서 enum으로 관리하고, 
    del이나, suspension 발생 시 값을 update해서 갖고 오기만 하는 게 최고 올바른 방향인 것 같은데, 
    엔티티랑 로직을 뜯어야 하는 것 같아서, 이렇게 get메서드 하나 만들었습니다.)
    - 신고 상세 내역 조회 시 각각 repo에 들려 값을 가져와서 발생하는 N+1을 fetchJoin 쿼리로 변경하여 DB 요청을 최소화했습니다.
    - 테스트코드란 걸 작성해보았습니다.. 

## 🔎 작업 내용


## 📣 공유 사항

