### PR TITLE
fix : 게시글,댓글 관련 업데이트 및 이미지 업로드 오류 수정

### DIFF
--- a/src/main/java/com/grepp/teamnotfound/app/controller/api/article/ArticleApiController.java
+++ b/src/main/java/com/grepp/teamnotfound/app/controller/api/article/ArticleApiController.java
@@ -37,6 +37,7 @@ public class ArticleApiController {
 
     @GetMapping("/v1")
     @Operation(summary = "특정 게시판의 게시글 리스트 조회")
+    @PreAuthorize("isAnonymous() or isAuthenticated()")
     public ResponseEntity<?> getAllArticles(
         @ModelAttribute @Valid ArticleListRequest request
     ) {

--- a/src/main/java/com/grepp/teamnotfound/app/controller/api/reply/ReplyApiController.java
+++ b/src/main/java/com/grepp/teamnotfound/app/controller/api/reply/ReplyApiController.java
@@ -33,6 +33,7 @@ public class ReplyApiController {
 
     @GetMapping("/v1")
     @Operation(summary = "특정 게시글의 댓글 리스트 조회")
+    @PreAuthorize("isAnonymous() or isAuthenticated()")
     public ResponseEntity<?> getAllReplies(
         @PathVariable Long articleId,
         @ModelAttribute @Valid ReplyListRequest request

--- a/src/main/java/com/grepp/teamnotfound/app/model/board/ArticleService.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/board/ArticleService.java
@@ -84,6 +84,10 @@ public class ArticleService {
         Board board = boardRepository.findByName(request.getBoardType().name())
             .orElseThrow(() -> new BoardException(BoardErrorCode.BOARD_NOT_FOUND));
 
+        if (!user.getState() || user.getSuspensionEndAt() != null) {
+            throw new BusinessException(UserErrorCode.USER_REPORTED);
+        }
+
         Article article = Article.builder()
             .title(request.getTitle())
             .content(request.getContent())
@@ -147,6 +151,10 @@ public class ArticleService {
 
         if (!beforeArticle.getBoard().getName().equals(request.getBoardType().name())) {
             throw new BoardException(BoardErrorCode.BOARD_CONFLICT);
+        }
+
+        if (!requestUser.getState() || requestUser.getSuspensionEndAt() != null) {
+            throw new BusinessException(UserErrorCode.USER_REPORTED);
         }
 
         beforeArticle.setTitle(request.getTitle());

--- a/src/main/java/com/grepp/teamnotfound/app/model/board/ArticleService.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/board/ArticleService.java
@@ -84,7 +84,7 @@ public class ArticleService {
         Board board = boardRepository.findByName(request.getBoardType().name())
             .orElseThrow(() -> new BoardException(BoardErrorCode.BOARD_NOT_FOUND));
 
-        if (!user.getState() || user.getSuspensionEndAt() != null) {
+        if (user.getSuspensionEndAt() != null) {
             throw new BusinessException(UserErrorCode.USER_REPORTED);
         }
 
@@ -153,7 +153,7 @@ public class ArticleService {
             throw new BoardException(BoardErrorCode.BOARD_CONFLICT);
         }
 
-        if (!requestUser.getState() || requestUser.getSuspensionEndAt() != null) {
+        if (requestUser.getSuspensionEndAt() != null) {
             throw new BusinessException(UserErrorCode.USER_REPORTED);
         }
 

--- a/src/main/java/com/grepp/teamnotfound/app/model/board/ArticleService.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/board/ArticleService.java
@@ -84,7 +84,7 @@ public class ArticleService {
         Board board = boardRepository.findByName(request.getBoardType().name())
             .orElseThrow(() -> new BoardException(BoardErrorCode.BOARD_NOT_FOUND));
 
-        if (user.getSuspensionEndAt() != null) {
+        if (user.getSuspensionEndAt() != null && user.getSuspensionEndAt().isAfter(OffsetDateTime.now())) {
             throw new BusinessException(UserErrorCode.USER_REPORTED);
         }
 
@@ -153,7 +153,8 @@ public class ArticleService {
             throw new BoardException(BoardErrorCode.BOARD_CONFLICT);
         }
 
-        if (requestUser.getSuspensionEndAt() != null) {
+        if (requestUser.getSuspensionEndAt() != null &&
+            requestUser.getSuspensionEndAt().isAfter(OffsetDateTime.now())) {
             throw new BusinessException(UserErrorCode.USER_REPORTED);
         }
 

--- a/src/main/java/com/grepp/teamnotfound/app/model/board/ArticleService.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/board/ArticleService.java
@@ -175,6 +175,7 @@ public class ArticleService {
         // 게시글을 삭제하면 댓글, 이미지 모두 soft delete
         OffsetDateTime deletedTime = OffsetDateTime.now();
         article.setDeletedAt(deletedTime);
+        article.setUpdatedAt(deletedTime);
         articleImgRepository.softDeleteByArticleId(articleId, deletedTime);
         articleLikeRepository.hardDeleteByArticleId(articleId);
         replyRepository.softDeleteByArticleId(articleId, deletedTime);

--- a/src/main/java/com/grepp/teamnotfound/app/model/board/repository/ArticleImgRepository.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/board/repository/ArticleImgRepository.java
@@ -16,6 +16,6 @@ public interface ArticleImgRepository extends JpaRepository<ArticleImg, Long> {
 
     @Transactional
     @Modifying(flushAutomatically = true, clearAutomatically = true)
-    @Query("UPDATE ArticleImg ai SET ai.deletedAt = :deletedAt WHERE ai.article.articleId = :articleId AND ai.deletedAt IS NULL ")
+    @Query("UPDATE ArticleImg ai SET ai.deletedAt = :deletedAt, ai.updatedAt = :deletedAt WHERE ai.article.articleId = :articleId AND ai.deletedAt IS NULL ")
     void softDeleteByArticleId(@Param("articleId") Long articleId, @Param("deletedAt") OffsetDateTime deletedAt);
 }

--- a/src/main/java/com/grepp/teamnotfound/app/model/reply/ReplyService.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/reply/ReplyService.java
@@ -47,7 +47,7 @@ public class ReplyService {
         Article article = articleRepository.findById(articleId)
             .orElseThrow(() -> new BoardException(BoardErrorCode.ARTICLE_NOT_FOUND));
 
-        if (!user.getState() || user.getSuspensionEndAt() != null) {
+        if (user.getSuspensionEndAt() != null) {
             throw new BusinessException(UserErrorCode.USER_REPORTED);
         }
 
@@ -85,7 +85,7 @@ public class ReplyService {
             throw new BoardException(BoardErrorCode.REPLY_FORBIDDEN);
         }
 
-        if (!user.getState() || user.getSuspensionEndAt() != null) {
+        if (user.getSuspensionEndAt() != null) {
             throw new BusinessException(UserErrorCode.USER_REPORTED);
         }
 

--- a/src/main/java/com/grepp/teamnotfound/app/model/reply/ReplyService.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/reply/ReplyService.java
@@ -112,7 +112,9 @@ public class ReplyService {
             throw new BoardException(BoardErrorCode.REPLY_FORBIDDEN);
         }
 
-        reply.setDeletedAt(OffsetDateTime.now());
+        OffsetDateTime deletedTime = OffsetDateTime.now();
+        reply.setDeletedAt(deletedTime);
+        reply.setUpdatedAt(deletedTime);
         replyRepository.save(reply);
     }
 

--- a/src/main/java/com/grepp/teamnotfound/app/model/reply/ReplyService.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/reply/ReplyService.java
@@ -47,7 +47,7 @@ public class ReplyService {
         Article article = articleRepository.findById(articleId)
             .orElseThrow(() -> new BoardException(BoardErrorCode.ARTICLE_NOT_FOUND));
 
-        if (user.getSuspensionEndAt() != null) {
+        if (user.getSuspensionEndAt() != null && user.getSuspensionEndAt().isAfter(OffsetDateTime.now())) {
             throw new BusinessException(UserErrorCode.USER_REPORTED);
         }
 
@@ -85,10 +85,9 @@ public class ReplyService {
             throw new BoardException(BoardErrorCode.REPLY_FORBIDDEN);
         }
 
-        if (user.getSuspensionEndAt() != null) {
+        if (user.getSuspensionEndAt() != null && user.getSuspensionEndAt().isAfter(OffsetDateTime.now())) {
             throw new BusinessException(UserErrorCode.USER_REPORTED);
         }
-
         reply.setContent(request.getContent());
         reply.setUpdatedAt(OffsetDateTime.now());
         Reply savedReply = replyRepository.save(reply);

--- a/src/main/java/com/grepp/teamnotfound/app/model/reply/ReplyService.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/reply/ReplyService.java
@@ -15,6 +15,7 @@ import com.grepp.teamnotfound.app.model.user.repository.UserImgRepository;
 import com.grepp.teamnotfound.app.model.user.repository.UserRepository;
 import com.grepp.teamnotfound.infra.error.exception.AuthException;
 import com.grepp.teamnotfound.infra.error.exception.BoardException;
+import com.grepp.teamnotfound.infra.error.exception.BusinessException;
 import com.grepp.teamnotfound.infra.error.exception.code.BoardErrorCode;
 import com.grepp.teamnotfound.infra.error.exception.code.UserErrorCode;
 import java.time.OffsetDateTime;
@@ -45,6 +46,10 @@ public class ReplyService {
             .orElseThrow(() -> new AuthException(UserErrorCode.USER_NOT_FOUND));
         Article article = articleRepository.findById(articleId)
             .orElseThrow(() -> new BoardException(BoardErrorCode.ARTICLE_NOT_FOUND));
+
+        if (!user.getState() || user.getSuspensionEndAt() != null) {
+            throw new BusinessException(UserErrorCode.USER_REPORTED);
+        }
 
         String profileImgPath = userService.getProfileImgPath(userId);
 
@@ -78,6 +83,10 @@ public class ReplyService {
 
         if (!reply.getUser().getUserId().equals(userId)) {
             throw new BoardException(BoardErrorCode.REPLY_FORBIDDEN);
+        }
+
+        if (!user.getState() || user.getSuspensionEndAt() != null) {
+            throw new BusinessException(UserErrorCode.USER_REPORTED);
         }
 
         reply.setContent(request.getContent());

--- a/src/main/java/com/grepp/teamnotfound/app/model/reply/repository/ReplyRepository.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/reply/repository/ReplyRepository.java
@@ -15,7 +15,7 @@ import org.springframework.data.repository.query.Param;
 public interface ReplyRepository extends JpaRepository<Reply, Long> {
 
     @Modifying(flushAutomatically = true, clearAutomatically = true)
-    @Query("UPDATE Reply r SET r.deletedAt = :deletedAt WHERE r.article.articleId = :articleId AND r.deletedAt IS NULL")
+    @Query("UPDATE Reply r SET r.deletedAt = :deletedAt, r.updatedAt = :deletedAt WHERE r.article.articleId = :articleId AND r.deletedAt IS NULL")
     void softDeleteByArticleId(@Param("articleId") Long articleId, @Param("deletedAt") OffsetDateTime deletedAt);
 
     Integer countByArticle_ArticleIdAndDeletedAtIsNullAndReportedAtIsNull(Long articleId);

--- a/src/main/java/com/grepp/teamnotfound/infra/error/exception/code/UserErrorCode.java
+++ b/src/main/java/com/grepp/teamnotfound/infra/error/exception/code/UserErrorCode.java
@@ -17,7 +17,8 @@ public enum UserErrorCode implements BaseErrorCode{
     EMAIL_ALREADY_VERIFIED(HttpStatus.BAD_REQUEST.value(), "USER_009", "이메일 인증이 이미 완료된 사용자입니다."),
     EMAIL_VERIFICATION_SEND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR.value(), "USER_008", "이메일 전송에 실패했습니다."),
     USER_ACCESS_DENIED(HttpStatus.FORBIDDEN.value(), "USER_007", "해당 사용자 정보에 대한 접근 권한이 없습니다."),
-    INVALID_PASSWORD_FORMAT(HttpStatus.BAD_REQUEST.value(), "USER_008", "비밀번호는 영문/숫자/특수문자를 포함한 8~20자여야 합니다.");
+    INVALID_PASSWORD_FORMAT(HttpStatus.BAD_REQUEST.value(), "USER_008", "비밀번호는 영문/숫자/특수문자를 포함한 8~20자여야 합니다."),
+    USER_REPORTED(HttpStatus.FORBIDDEN.value(), "USER_009", "신고로 인해 게시글/댓글 작성이 제한되었습니다.");
 
     private final int status;
     private final String code;

--- a/src/main/java/com/grepp/teamnotfound/infra/util/file/FileManager.java
+++ b/src/main/java/com/grepp/teamnotfound/infra/util/file/FileManager.java
@@ -6,7 +6,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 
-@Component
 public class FileManager extends AbstractFileManager {
 
     @Value("${upload.path}")

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,6 @@
 
-upload.path=C:/backend/f_spring/upload/
+# Cloud Run 컨테이너가 제공하는 스토리지 사용
+upload.path=/tmp/uploads/
 app.domain=http://localhost:8080
 front-server.domain=http://localhost:3000
 


### PR DESCRIPTION
## ✅ PR 올리기 전에
- [x] `dev`에서 `pull` 받았나요?
- [x] `merge conflict` 발생 시, 해결하고 올리셨나요?
- [x] 자신이 작업한 `changes`만 존재하나요?
- [ ] 작업 중 DB 변경이 발생했나요?

## 🐶 구현한 기능
- 게시글, 댓글 삭제시 updatedAt 반영
- 게시글, 댓글 작성시 회원 제재여부 확인
- 이미지 업로드 오류 수정

## 🔎 작업 내용
- **게시글과 댓글 삭제시** `deletedAt` & `updatedAt` 동시 업데이트
- **게시글과 댓글 작성시** user 의 `suspensionEndAt` 확인 -> null 일 경우에만 작성, 수정 가능
- `application.properties` 기존의 업로드 경로는 Google Cloud Run 에서 쓰기(write) 불가
    - 이미지 업로드 시 FileManager 로직이 실행되는 과정에서 오류 발생
    - 비즈니스 예외가 터지기도 전에 **권한 에러(Permission Denied)** 가 발생해서 500 에러 반환 -> 아예 로그가 안남음
    - `/tmp` 경로는 Google Cloud Run 에서 쓰기 권한이 있는 폴더 -> 오류가 발생하지 않음

