### PR TITLE
Feat : 버킷 이미지 정리 스케줄러 구현

### DIFF
--- a/src/main/java/com/grepp/teamnotfound/app/model/board/entity/ArticleImg.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/board/entity/ArticleImg.java
@@ -1,5 +1,6 @@
 package com.grepp.teamnotfound.app.model.board.entity;
 
+import com.grepp.teamnotfound.infra.util.file.ImageFile;
 import com.grepp.teamnotfound.infra.code.ImgType;
 import com.grepp.teamnotfound.infra.entity.BaseEntity;
 import com.grepp.teamnotfound.infra.util.file.FileDto;
@@ -15,6 +16,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
+import java.time.OffsetDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -28,7 +30,7 @@ import lombok.Setter;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-public class ArticleImg extends BaseEntity {
+public class ArticleImg extends BaseEntity implements ImageFile {
 
     @Id
     @Column(nullable = false, updatable = false)
@@ -68,5 +70,20 @@ public class ArticleImg extends BaseEntity {
             .originName(fileDto.originName())
             .renamedName(fileDto.renamedName())
             .build();
+    }
+
+    @Override
+    public OffsetDateTime getDeletedAt() {
+        return super.getDeletedAt();
+    }
+
+    @Override
+    public FileDto toFileDto() {
+        return new FileDto(
+            this.originName,
+            this.renamedName,
+            "article",
+            this.savePath
+        );
     }
 }

--- a/src/main/java/com/grepp/teamnotfound/app/model/board/repository/ArticleImgRepository.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/board/repository/ArticleImgRepository.java
@@ -18,4 +18,6 @@ public interface ArticleImgRepository extends JpaRepository<ArticleImg, Long> {
     @Modifying(flushAutomatically = true, clearAutomatically = true)
     @Query("UPDATE ArticleImg ai SET ai.deletedAt = :deletedAt, ai.updatedAt = :deletedAt WHERE ai.article.articleId = :articleId AND ai.deletedAt IS NULL ")
     void softDeleteByArticleId(@Param("articleId") Long articleId, @Param("deletedAt") OffsetDateTime deletedAt);
+
+    List<ArticleImg> findByDeletedAtBefore(OffsetDateTime dateTime);
 }

--- a/src/main/java/com/grepp/teamnotfound/app/model/board/repository/ArticleImgRepository.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/board/repository/ArticleImgRepository.java
@@ -19,5 +19,5 @@ public interface ArticleImgRepository extends JpaRepository<ArticleImg, Long> {
     @Query("UPDATE ArticleImg ai SET ai.deletedAt = :deletedAt, ai.updatedAt = :deletedAt WHERE ai.article.articleId = :articleId AND ai.deletedAt IS NULL ")
     void softDeleteByArticleId(@Param("articleId") Long articleId, @Param("deletedAt") OffsetDateTime deletedAt);
 
-    List<ArticleImg> findByDeletedAtBefore(OffsetDateTime dateTime);
+    List<ArticleImg> findByDeletedAtBetween(OffsetDateTime startOfTargetDay, OffsetDateTime endOfTargetDay);
 }

--- a/src/main/java/com/grepp/teamnotfound/app/model/pet/entity/PetImg.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/pet/entity/PetImg.java
@@ -1,7 +1,9 @@
 package com.grepp.teamnotfound.app.model.pet.entity;
 
+import com.grepp.teamnotfound.infra.util.file.ImageFile;
 import com.grepp.teamnotfound.infra.code.ImgType;
 import com.grepp.teamnotfound.infra.entity.BaseEntity;
+import com.grepp.teamnotfound.infra.util.file.FileDto;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -14,6 +16,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
+import java.time.OffsetDateTime;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -22,7 +25,7 @@ import lombok.Setter;
 @Table(name = "PetImgs")
 @Getter
 @Setter
-public class PetImg extends BaseEntity {
+public class PetImg extends BaseEntity implements ImageFile {
 
     @Id
     @Column(nullable = false, updatable = false)
@@ -55,5 +58,19 @@ public class PetImg extends BaseEntity {
     @JoinColumn(name = "pet_id", nullable = false)
     private Pet pet;
 
+    @Override
+    public OffsetDateTime getDeletedAt() {
+        return super.getDeletedAt();
+    }
+
+    @Override
+    public FileDto toFileDto() {
+        return new FileDto(
+            this.originName,
+            this.renamedName,
+            "pet",
+            this.savePath
+        );
+    }
 }
 

--- a/src/main/java/com/grepp/teamnotfound/app/model/pet/repository/PetImgRepository.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/pet/repository/PetImgRepository.java
@@ -2,6 +2,8 @@ package com.grepp.teamnotfound.app.model.pet.repository;
 
 import com.grepp.teamnotfound.app.model.pet.entity.PetImg;
 import feign.Param;
+import java.time.OffsetDateTime;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -16,4 +18,5 @@ public interface PetImgRepository extends JpaRepository<PetImg, Long> {
     @Query("UPDATE PetImg pi SET pi.deletedAt = CURRENT_TIMESTAMP WHERE pi.pet.petId = :petId AND pi.deletedAt IS NULL")
     void softDeletePetImg(@Param("petId") Long petId);
 
+    List<PetImg> findByDeletedAtBefore(OffsetDateTime dateTime);
 }

--- a/src/main/java/com/grepp/teamnotfound/app/model/pet/repository/PetImgRepository.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/pet/repository/PetImgRepository.java
@@ -18,5 +18,5 @@ public interface PetImgRepository extends JpaRepository<PetImg, Long> {
     @Query("UPDATE PetImg pi SET pi.deletedAt = CURRENT_TIMESTAMP WHERE pi.pet.petId = :petId AND pi.deletedAt IS NULL")
     void softDeletePetImg(@Param("petId") Long petId);
 
-    List<PetImg> findByDeletedAtBefore(OffsetDateTime dateTime);
+    List<PetImg> findByDeletedAtBetween(OffsetDateTime startOfTargetDay, OffsetDateTime endOfTargetDay);
 }

--- a/src/main/java/com/grepp/teamnotfound/app/model/user/entity/UserImg.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/user/entity/UserImg.java
@@ -1,7 +1,9 @@
 package com.grepp.teamnotfound.app.model.user.entity;
 
+import com.grepp.teamnotfound.infra.util.file.ImageFile;
 import com.grepp.teamnotfound.infra.code.ImgType;
 import com.grepp.teamnotfound.infra.entity.BaseEntity;
+import com.grepp.teamnotfound.infra.util.file.FileDto;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -14,6 +16,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
+import java.time.OffsetDateTime;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -22,7 +25,7 @@ import lombok.Setter;
 @Table(name = "UserImgs")
 @Getter
 @Setter
-public class UserImg extends BaseEntity {
+public class UserImg extends BaseEntity implements ImageFile {
 
     @Id
     @Column(nullable = false, updatable = false)
@@ -55,5 +58,19 @@ public class UserImg extends BaseEntity {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
+    @Override
+    public OffsetDateTime getDeletedAt() {
+        return super.getDeletedAt();
+    }
+
+    @Override
+    public FileDto toFileDto() {
+        return new FileDto(
+            this.originName,
+            this.renamedName,
+            "user",
+            this.savePath
+        );
+    }
 }
 

--- a/src/main/java/com/grepp/teamnotfound/app/model/user/repository/UserImgRepository.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/user/repository/UserImgRepository.java
@@ -17,5 +17,5 @@ public interface UserImgRepository extends JpaRepository<UserImg, Long> {
     @Query("UPDATE UserImg ui SET ui.deletedAt = CURRENT_TIMESTAMP WHERE ui.user.userId = :userId AND ui.deletedAt IS NULL")
     void softDeleteUserImg(@Param("userId") Long userId);
 
-    List<UserImg> findByDeletedAtBefore(OffsetDateTime thresholdTime);
+    List<UserImg> findByDeletedAtBetween(OffsetDateTime startOfTargetDay, OffsetDateTime endOfTargetDay);
 }

--- a/src/main/java/com/grepp/teamnotfound/app/model/user/repository/UserImgRepository.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/user/repository/UserImgRepository.java
@@ -2,6 +2,8 @@ package com.grepp.teamnotfound.app.model.user.repository;
 
 import com.grepp.teamnotfound.app.model.user.entity.UserImg;
 import feign.Param;
+import java.time.OffsetDateTime;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -14,4 +16,6 @@ public interface UserImgRepository extends JpaRepository<UserImg, Long> {
     @Modifying(clearAutomatically=true, flushAutomatically=true)
     @Query("UPDATE UserImg ui SET ui.deletedAt = CURRENT_TIMESTAMP WHERE ui.user.userId = :userId AND ui.deletedAt IS NULL")
     void softDeleteUserImg(@Param("userId") Long userId);
+
+    List<UserImg> findByDeletedAtBefore(OffsetDateTime thresholdTime);
 }

--- a/src/main/java/com/grepp/teamnotfound/infra/util/file/AbstractFileManager.java
+++ b/src/main/java/com/grepp/teamnotfound/infra/util/file/AbstractFileManager.java
@@ -30,7 +30,7 @@ public abstract class AbstractFileManager {
     }
 
     public void delete(List<FileDto> fileDtos) {
-        // 사진 일괄 삭제 메서드
+
     }
 
     protected void uploadFile(MultipartFile file, FileDto fileDto) throws IOException {

--- a/src/main/java/com/grepp/teamnotfound/infra/util/file/AbstractFileManager.java
+++ b/src/main/java/com/grepp/teamnotfound/infra/util/file/AbstractFileManager.java
@@ -30,7 +30,7 @@ public abstract class AbstractFileManager {
     }
 
     public void delete(List<FileDto> fileDtos) {
-
+        // 사진 일괄 삭제 메서드
     }
 
     protected void uploadFile(MultipartFile file, FileDto fileDto) throws IOException {

--- a/src/main/java/com/grepp/teamnotfound/infra/util/file/FileDto.java
+++ b/src/main/java/com/grepp/teamnotfound/infra/util/file/FileDto.java
@@ -1,5 +1,9 @@
 package com.grepp.teamnotfound.infra.util.file;
 
+import com.grepp.teamnotfound.app.model.board.entity.ArticleImg;
+import com.grepp.teamnotfound.app.model.pet.entity.PetImg;
+import com.grepp.teamnotfound.app.model.user.entity.UserImg;
+
 public record FileDto(
     String originName,
     String renamedName,
@@ -7,4 +11,30 @@ public record FileDto(
     String savePath
 ) {
 
+    public static FileDto fromArticleImg(ArticleImg articleImg) {
+        return new FileDto(
+            articleImg.getOriginName(),
+            articleImg.getRenamedName(),
+            "article",
+            articleImg.getSavePath()
+        );
+    }
+
+    public static FileDto fromPetImg(PetImg petImg) {
+        return new FileDto(
+            petImg.getOriginName(),
+            petImg.getRenamedName(),
+            "pet",
+            petImg.getSavePath()
+        );
+    }
+
+    public static FileDto fromUserImg(UserImg userImg) {
+        return new FileDto(
+            userImg.getOriginName(),
+            userImg.getRenamedName(),
+            "user",
+            userImg.getSavePath()
+        );
+    }
 }

--- a/src/main/java/com/grepp/teamnotfound/infra/util/file/FileDto.java
+++ b/src/main/java/com/grepp/teamnotfound/infra/util/file/FileDto.java
@@ -11,30 +11,4 @@ public record FileDto(
     String savePath
 ) {
 
-    public static FileDto fromArticleImg(ArticleImg articleImg) {
-        return new FileDto(
-            articleImg.getOriginName(),
-            articleImg.getRenamedName(),
-            "article",
-            articleImg.getSavePath()
-        );
-    }
-
-    public static FileDto fromPetImg(PetImg petImg) {
-        return new FileDto(
-            petImg.getOriginName(),
-            petImg.getRenamedName(),
-            "pet",
-            petImg.getSavePath()
-        );
-    }
-
-    public static FileDto fromUserImg(UserImg userImg) {
-        return new FileDto(
-            userImg.getOriginName(),
-            userImg.getRenamedName(),
-            "user",
-            userImg.getSavePath()
-        );
-    }
 }

--- a/src/main/java/com/grepp/teamnotfound/infra/util/file/GoogleStorageManager.java
+++ b/src/main/java/com/grepp/teamnotfound/infra/util/file/GoogleStorageManager.java
@@ -37,7 +37,18 @@ public class GoogleStorageManager extends AbstractFileManager {
     }
 
     @Override
+    public void delete(List<FileDto> fileDtos) {
+        if (fileDtos == null || fileDtos.isEmpty()) {
+            return;
+        }
+        for (FileDto fileDto : fileDtos) {
+            deleteFile(fileDto);
+        }
+    }
+
+    @Override
     protected void deleteFile(FileDto fileDto) {
+        // fileDto.savePath() = storageBaseUrl + bucket + / + depth + /
         Storage storage = StorageOptions.getDefaultInstance().getService();
         String objectName = fileDto.depth() + "/" + fileDto.renamedName();
         BlobId blobId = BlobId.of(bucket, objectName);
@@ -45,11 +56,14 @@ public class GoogleStorageManager extends AbstractFileManager {
         boolean deleted = storage.delete(blobId);
         if (!deleted) {
             log.warn("GCS 파일 삭제 실패: {}", objectName);
+        } else {
+            log.info("GCS 파일 삭제 성공: {}", objectName);
         }
     }
 
     @Override
     protected String createSavePath(String depth) {
+        // NOTE 연/월/일 경로로 할 건지 수정 필요
         return storageBaseUrl + bucket + "/" + depth + "/";
     }
 }

--- a/src/main/java/com/grepp/teamnotfound/infra/util/file/GoogleStorageManager.java
+++ b/src/main/java/com/grepp/teamnotfound/infra/util/file/GoogleStorageManager.java
@@ -63,7 +63,6 @@ public class GoogleStorageManager extends AbstractFileManager {
 
     @Override
     protected String createSavePath(String depth) {
-        // NOTE 연/월/일 경로로 할 건지 수정 필요
         return storageBaseUrl + bucket + "/" + depth + "/";
     }
 }

--- a/src/main/java/com/grepp/teamnotfound/infra/util/file/ImageCleanScheduler.java
+++ b/src/main/java/com/grepp/teamnotfound/infra/util/file/ImageCleanScheduler.java
@@ -6,8 +6,8 @@ import com.grepp.teamnotfound.app.model.pet.entity.PetImg;
 import com.grepp.teamnotfound.app.model.pet.repository.PetImgRepository;
 import com.grepp.teamnotfound.app.model.user.entity.UserImg;
 import com.grepp.teamnotfound.app.model.user.repository.UserImgRepository;
+import java.time.LocalTime;
 import java.time.OffsetDateTime;
-import java.time.temporal.ChronoUnit;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -26,59 +26,45 @@ public class ImageCleanScheduler {
     private final UserImgRepository userImgRepository;
     private final GoogleStorageManager fileManager;
 
-    // 소프트 딜리트 후 이미지를 양구 삭제할 기간
+    // 소프트 딜리트 후 보존 기간
     @Value("${image.clean.period-days}")
     private int softDeletePeriodDays;
 
     // 매일 오전 1시에 실행
-//    @Scheduled(cron = "0 0 1 * * *")
-    @Scheduled(cron = "0 * * * * *")
+    @Scheduled(cron = "0 0 1 * * *", zone = "Asia/Seoul")
     @Transactional
     public void cleanSoftDeletedImages() {
         log.info("Start image clean up scheduler...");
 
-        OffsetDateTime thresholdTime = OffsetDateTime.now().minusDays(softDeletePeriodDays);
+        OffsetDateTime targetDate = OffsetDateTime.now().minusDays(softDeletePeriodDays);
+        OffsetDateTime startOfTargetDay = targetDate.with(LocalTime.MIN);
+        OffsetDateTime endOfTargetDay = targetDate.with(LocalTime.MAX);
 
-        // 1. ArticleImg 정리
-        List<ArticleImg> articleImgsToClean = articleImgRepository.findByDeletedAtBefore(thresholdTime);
-        if (!articleImgsToClean.isEmpty()) {
-            List<FileDto> articleFileDtos = articleImgsToClean.stream()
-                .map(FileDto::fromArticleImg)
-                .toList();
+        List<ArticleImg> articleImgsToClean = articleImgRepository.findByDeletedAtBetween(startOfTargetDay, endOfTargetDay);
+        cleanImages(articleImgsToClean, "article");
 
-            fileManager.delete(articleFileDtos);
-            log.info("Images clean up processing finished for {} articles. ",
-                articleImgsToClean.size());
-        } else {
-            log.info("No article images to clean up.");
-        }
+        List<PetImg> petImgsToClean = petImgRepository.findByDeletedAtBetween(startOfTargetDay, endOfTargetDay);
+        cleanImages(petImgsToClean, "pet");
 
-        // 2. PetImg 정리
-        List<PetImg> petImgsToClean = petImgRepository.findByDeletedAtBefore(thresholdTime);
-        if (!petImgsToClean.isEmpty()) {
-            List<FileDto> petFileDtos = petImgsToClean.stream()
-                .map(FileDto::fromPetImg)
-                .toList();
-
-            fileManager.delete(petFileDtos);
-            log.info("Image clean up processing finished for {} pets.", petImgsToClean.size());
-        } else {
-            log.info("No pet images to clean up.");
-        }
-
-        // 3. UserImg 정리
-        List<UserImg> userImgsToClean = userImgRepository.findByDeletedAtBefore(thresholdTime);
-        if (!userImgsToClean.isEmpty()) {
-            List<FileDto> userFileDtos = userImgsToClean.stream()
-                .map(FileDto::fromUserImg)
-                .toList();
-
-            fileManager.delete(userFileDtos);
-            log.info("Image clean up processing finished for {} users.", userImgsToClean.size());
-        } else {
-            log.info("No user images to clean up.");
-        }
+        List<UserImg> userImgsToClean = userImgRepository.findByDeletedAtBetween(startOfTargetDay, endOfTargetDay);
+        cleanImages(userImgsToClean, "user");
 
         log.info("Finish image clean up scheduler.");
+    }
+
+    private <T extends ImageFile> void cleanImages(
+        List<T> imgsToClean,
+        String entityName
+    ) {
+        if (!imgsToClean.isEmpty()) {
+            List<FileDto> fileDtos = imgsToClean.stream()
+                .map(ImageFile::toFileDto)
+                .toList();
+
+            fileManager.delete(fileDtos);
+            log.info("Image clean up processing finished for {} {}.", imgsToClean.size(), entityName);
+        } else {
+            log.info("No {} images to clean up.", entityName);
+        }
     }
 }

--- a/src/main/java/com/grepp/teamnotfound/infra/util/file/ImageCleanScheduler.java
+++ b/src/main/java/com/grepp/teamnotfound/infra/util/file/ImageCleanScheduler.java
@@ -1,0 +1,84 @@
+package com.grepp.teamnotfound.infra.util.file;
+
+import com.grepp.teamnotfound.app.model.board.entity.ArticleImg;
+import com.grepp.teamnotfound.app.model.board.repository.ArticleImgRepository;
+import com.grepp.teamnotfound.app.model.pet.entity.PetImg;
+import com.grepp.teamnotfound.app.model.pet.repository.PetImgRepository;
+import com.grepp.teamnotfound.app.model.user.entity.UserImg;
+import com.grepp.teamnotfound.app.model.user.repository.UserImgRepository;
+import java.time.OffsetDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ImageCleanScheduler {
+
+    private final ArticleImgRepository articleImgRepository;
+    private final PetImgRepository petImgRepository;
+    private final UserImgRepository userImgRepository;
+    private final GoogleStorageManager fileManager;
+
+    // 소프트 딜리트 후 이미지를 양구 삭제할 기간
+    @Value("${image.clean.period-days}")
+    private int softDeletePeriodDays;
+
+    // 매일 오전 1시에 실행
+//    @Scheduled(cron = "0 0 1 * * *")
+    @Scheduled(cron = "0 * * * * *")
+    @Transactional
+    public void cleanSoftDeletedImages() {
+        log.info("Start image clean up scheduler...");
+
+        OffsetDateTime thresholdTime = OffsetDateTime.now().minusDays(softDeletePeriodDays);
+
+        // 1. ArticleImg 정리
+        List<ArticleImg> articleImgsToClean = articleImgRepository.findByDeletedAtBefore(thresholdTime);
+        if (!articleImgsToClean.isEmpty()) {
+            List<FileDto> articleFileDtos = articleImgsToClean.stream()
+                .map(FileDto::fromArticleImg)
+                .toList();
+
+            fileManager.delete(articleFileDtos);
+            log.info("Images clean up processing finished for {} articles. ",
+                articleImgsToClean.size());
+        } else {
+            log.info("No article images to clean up.");
+        }
+
+        // 2. PetImg 정리
+        List<PetImg> petImgsToClean = petImgRepository.findByDeletedAtBefore(thresholdTime);
+        if (!petImgsToClean.isEmpty()) {
+            List<FileDto> petFileDtos = petImgsToClean.stream()
+                .map(FileDto::fromPetImg)
+                .toList();
+
+            fileManager.delete(petFileDtos);
+            log.info("Image clean up processing finished for {} pets.", petImgsToClean.size());
+        } else {
+            log.info("No pet images to clean up.");
+        }
+
+        // 3. UserImg 정리
+        List<UserImg> userImgsToClean = userImgRepository.findByDeletedAtBefore(thresholdTime);
+        if (!userImgsToClean.isEmpty()) {
+            List<FileDto> userFileDtos = userImgsToClean.stream()
+                .map(FileDto::fromUserImg)
+                .toList();
+
+            fileManager.delete(userFileDtos);
+            log.info("Image clean up processing finished for {} users.", userImgsToClean.size());
+        } else {
+            log.info("No user images to clean up.");
+        }
+
+        log.info("Finish image clean up scheduler.");
+    }
+}

--- a/src/main/java/com/grepp/teamnotfound/infra/util/file/ImageFile.java
+++ b/src/main/java/com/grepp/teamnotfound/infra/util/file/ImageFile.java
@@ -1,0 +1,9 @@
+package com.grepp.teamnotfound.infra.util.file;
+
+import java.time.OffsetDateTime;
+
+public interface ImageFile {
+
+    OffsetDateTime getDeletedAt(); // soft delete 가 적용되는 이미지임을 나타냄
+    FileDto toFileDto();
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -73,6 +73,7 @@ springdoc.swagger-ui.try-it-out-enabled=true
 
 # bucket
 google.cloud.storage.bucket=mungnote-storage
+image.clean.period-days=30
 
 
 


### PR DESCRIPTION
## ✅ PR 올리기 전에
- [x] `dev`에서 `pull` 받았나요?
- [x] `merge conflict` 발생 시, 해결하고 올리셨나요?
- [x] 자신이 작업한 `changes`만 존재하나요?
- [ ] 작업 중 DB 변경이 발생했나요?

## 🐶 구현한 기능
- **버킷 이미지 정리 스케줄러** 구현

## 🔎 작업 내용
- soft delete 후 이미지 보존기간 : 30일(변경가능)
- `ImageFile` 인터페이스 생성 
    - `ArticleImg`, `PetImg`, `UserImg` 모두 해당 인터페이스를 구현
- `ImageCleanScheduler` 에서 매일 오전 1시(변경가능)에 버킷 이미지 정리 스케줄링 실행

