### PR TITLE
Fix : 탈퇴한 회원 로그인 불가 처리 및 기타 리팩토링

### DIFF
--- a/src/main/java/com/grepp/teamnotfound/app/controller/api/admin/AdminController.java
+++ b/src/main/java/com/grepp/teamnotfound/app/controller/api/admin/AdminController.java
@@ -32,39 +32,26 @@ public class AdminController {
     @Operation(summary = "전체 가입자 수 조회")
     @GetMapping("v1/stats/users")
     public ResponseEntity<UserCountResponse> getUsersCount(){
-        TotalUsersDto totalUsersDto = adminService.getTotalUsersCount();
-        UserCountResponse response = UserCountResponse.builder()
-                .date(OffsetDateTime.now())
-                .total(totalUsersDto.getTotal())
-                .build();
+        TotalUsersDto dto = adminService.getTotalUsersCount();
+        UserCountResponse response = UserCountResponse.of(dto);
         return ResponseEntity.ok(response);
     }
 
     @Operation(summary = "회원 목록 조회")
     @GetMapping("v1/users")
     public ResponseEntity<UsersListResponse> getUsers(
-            @Valid @ModelAttribute UsersListRequest request
-            ){
+            @Valid @ModelAttribute UsersListRequest request){
         Page<UsersListDto> userPage = adminService.getUsersList(request);
-        UsersListResponse response = UsersListResponse.builder()
-                .users(userPage.getContent())
-                .pageInfo(PageInfo.fromPage(userPage))
-                .build();
-
+        UsersListResponse response = UsersListResponse.of(userPage);
         return ResponseEntity.ok(response);
     }
 
     @Operation(summary = "신고 내역 목록 조회")
     @GetMapping("v1/reports")
     public ResponseEntity<ReportsListResponse> getReports(
-            @Valid @ModelAttribute ReportsListRequest request
-    ){
+            @Valid @ModelAttribute ReportsListRequest request){
         Page<ReportsListDto> reportPage = adminService.getReportsList(request);
-        ReportsListResponse response = ReportsListResponse.builder()
-                .reports(reportPage.getContent())
-                .pageInfo(PageInfo.fromPage(reportPage))
-                .build();
-
+        ReportsListResponse response = ReportsListResponse.of(reportPage);
         return ResponseEntity.ok(response);
     }
 
@@ -126,13 +113,7 @@ public class AdminController {
     @Operation(summary = "신고 처리하기")
     @PatchMapping("v1/reports/result-accept")
     public ResponseEntity<?> acceptReport(@RequestBody AcceptReportRequest request){
-
-        AcceptReportDto dto = AcceptReportDto.builder()
-                .reportId(request.getReportId())
-                .adminReason(request.getAdminReason())
-                .period(request.getPeriod())
-                .build();
-
+        AcceptReportDto dto = AcceptReportDto.of(request);
         adminService.acceptReportAndSuspendUser(dto);
         return ResponseEntity.ok("신고가 정상적으로 처리되었습니다.");
     }
@@ -140,12 +121,7 @@ public class AdminController {
     @Operation(summary = "신고 철회하기")
     @PatchMapping("v1/reports/result-reject")
     public ResponseEntity<?> rejectReport(@RequestBody RejectReportRequest request){
-
-        RejectReportDto dto = RejectReportDto.builder()
-                .reportId(request.getReportId())
-                .adminReason(request.getAdminReason())
-                .build();
-
+        RejectReportDto dto = RejectReportDto.of(request);
         adminService.rejectReport(dto);
         return ResponseEntity.ok("신고를 성공적으로 거절하였습니다.");
     }

--- a/src/main/java/com/grepp/teamnotfound/app/controller/api/admin/payload/ReportsListResponse.java
+++ b/src/main/java/com/grepp/teamnotfound/app/controller/api/admin/payload/ReportsListResponse.java
@@ -3,6 +3,7 @@ package com.grepp.teamnotfound.app.controller.api.admin.payload;
 import com.grepp.teamnotfound.app.model.report.dto.ReportsListDto;
 import lombok.Builder;
 import lombok.Data;
+import org.springframework.data.domain.Page;
 
 import java.util.List;
 
@@ -12,4 +13,11 @@ public class ReportsListResponse {
 
     private List<ReportsListDto> reports;
     private PageInfo pageInfo;
+
+    public static ReportsListResponse of(Page<ReportsListDto> reportPage) {
+        return ReportsListResponse.builder()
+                .reports(reportPage.getContent())
+                .pageInfo(PageInfo.fromPage(reportPage))
+                .build();
+    }
 }

--- a/src/main/java/com/grepp/teamnotfound/app/controller/api/admin/payload/UserCountResponse.java
+++ b/src/main/java/com/grepp/teamnotfound/app/controller/api/admin/payload/UserCountResponse.java
@@ -1,5 +1,6 @@
 package com.grepp.teamnotfound.app.controller.api.admin.payload;
 
+import com.grepp.teamnotfound.app.model.user.dto.TotalUsersDto;
 import lombok.Builder;
 import lombok.Data;
 import lombok.Getter;
@@ -12,4 +13,11 @@ public class UserCountResponse {
 
     private OffsetDateTime date;
     private long total;
+
+    public static UserCountResponse of(TotalUsersDto dto) {
+        return UserCountResponse.builder()
+                .date(OffsetDateTime.now())
+                .total(dto.getTotal())
+                .build();
+    }
 }

--- a/src/main/java/com/grepp/teamnotfound/app/controller/api/admin/payload/UsersListResponse.java
+++ b/src/main/java/com/grepp/teamnotfound/app/controller/api/admin/payload/UsersListResponse.java
@@ -3,8 +3,8 @@ package com.grepp.teamnotfound.app.controller.api.admin.payload;
 import com.grepp.teamnotfound.app.model.user.dto.UsersListDto;
 import lombok.Builder;
 import lombok.Data;
+import org.springframework.data.domain.Page;
 
-import java.time.OffsetDateTime;
 import java.util.List;
 
 @Data
@@ -13,4 +13,11 @@ public class UsersListResponse {
 
     private List<UsersListDto> users;
     private PageInfo pageInfo;
+
+    public static UsersListResponse of(Page<UsersListDto> userPage){
+        return UsersListResponse.builder()
+                .users(userPage.getContent())
+                .pageInfo(PageInfo.fromPage(userPage))
+                .build();
+    }
 }

--- a/src/main/java/com/grepp/teamnotfound/app/controller/api/auth/AuthController.java
+++ b/src/main/java/com/grepp/teamnotfound/app/controller/api/auth/AuthController.java
@@ -1,5 +1,6 @@
 package com.grepp.teamnotfound.app.controller.api.auth;
 
+import com.grepp.teamnotfound.app.controller.api.auth.code.ProviderType;
 import com.grepp.teamnotfound.app.controller.api.auth.payload.EmailVerificationRequest;
 import com.grepp.teamnotfound.app.controller.api.auth.payload.EmailVerifyRequest;
 import com.grepp.teamnotfound.app.controller.api.auth.payload.LoginRequest;
@@ -95,7 +96,8 @@ public class AuthController {
     @Operation(summary = "소셜 로그인")
     @GetMapping("v1/social-auth/{provider}")
     public ResponseEntity<?> socialLogin(@PathVariable String provider) {
-        String url = customOAuth2UserService.getAuthUrl(provider);
+        ProviderType providerType = ProviderType.valueOf(provider.toUpperCase());
+        String url = customOAuth2UserService.getAuthUrl(providerType);
         return ResponseEntity.ok(url);
     }
 

--- a/src/main/java/com/grepp/teamnotfound/app/controller/api/auth/AuthController.java
+++ b/src/main/java/com/grepp/teamnotfound/app/controller/api/auth/AuthController.java
@@ -75,18 +75,10 @@ public class AuthController {
     @Operation(summary = "최종 회원가입")
     @PostMapping("v2/register")
     public ResponseEntity<ApiResponse<?>> register(@RequestBody RegisterRequest request) {
-
-        RegisterCommand command = RegisterCommand.builder()
-                .email(request.getEmail())
-                .name(request.getName())
-                .nickname(request.getNickname())
-                .password(request.getPassword())
-                .build();
+        RegisterCommand command = RegisterCommand.of(request);
         Long userId = userService.registerUser(command);
         RegisterResponse response = new RegisterResponse(userId);
-
         notificationService.createManagement(userId);
-
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
@@ -94,13 +86,7 @@ public class AuthController {
     @PostMapping("v2/admin/register")
     @PreAuthorize("permitAll()")
     public ResponseEntity<ApiResponse<?>> registerAdmin(@RequestBody RegisterRequest request) {
-
-        RegisterCommand command = RegisterCommand.builder()
-                .email(request.getEmail())
-                .name(request.getName())
-                .nickname(request.getNickname())
-                .password(request.getPassword())
-                .build();
+        RegisterCommand command = RegisterCommand.of(request);
         Long userId = userService.registerAdmin(command);
         RegisterResponse response = new RegisterResponse(userId);
         return ResponseEntity.ok(ApiResponse.success(response));
@@ -117,26 +103,12 @@ public class AuthController {
     @Operation(summary = "회원 로그인")
     @PostMapping("v1/login")
     public ResponseEntity<ApiResponse<LoginResponse>> login(@RequestBody LoginRequest request, HttpServletResponse response) {
-
-        LoginCommand command = LoginCommand.builder()
-                .email(request.getEmail())
-                .password(request.getPassword())
-                .build();
-
+        LoginCommand command = LoginCommand.of(request);
         LoginResult dto = authService.login(command);
         createAuthTokenCookies(dto, response);
 
-        TokenResponse tokenResponse = TokenResponse.builder()
-                .accessToken(dto.getAccessToken())
-                .expiresIn(dto.getAtExpiresIn())
-                .grantType(GrantType.BEARER)
-                .refreshToken(dto.getRefreshToken())
-                .build();
-
-        LoginResponse loginResponse = LoginResponse.builder()
-                .tokenResponse(tokenResponse)
-                .userId(dto.getUserId())
-                .build();
+        TokenResponse tokenResponse = TokenResponse.of(dto);
+        LoginResponse loginResponse = LoginResponse.of(tokenResponse, dto);
         return ResponseEntity.ok(ApiResponse.success(loginResponse));
 
     }
@@ -147,27 +119,14 @@ public class AuthController {
     @PreAuthorize("permitAll()")
     public ResponseEntity<ApiResponse<LoginResponse>> adminLogin(@RequestBody LoginRequest request, HttpServletResponse response) {
 
-        LoginCommand command = LoginCommand.builder()
-                .email(request.getEmail())
-                .password(request.getPassword())
-                .build();
+        LoginCommand command = LoginCommand.of(request);
 
         LoginResult dto = authService.adminLogin(command);
         createAuthTokenCookies(dto, response);
 
-        TokenResponse tokenResponse = TokenResponse.builder()
-                .accessToken(dto.getAccessToken())
-                .expiresIn(dto.getAtExpiresIn())
-                .grantType(GrantType.BEARER)
-                .refreshToken(dto.getRefreshToken())
-                .build();
-
-        LoginResponse loginResponse = LoginResponse.builder()
-                .tokenResponse(tokenResponse)
-                .userId(dto.getUserId())
-                .build();
+        TokenResponse tokenResponse = TokenResponse.of(dto);
+        LoginResponse loginResponse = LoginResponse.of(tokenResponse, dto);
         return ResponseEntity.ok(ApiResponse.success(loginResponse));
-
     }
 
     private void createAuthTokenCookies(LoginResult dto, HttpServletResponse response) {

--- a/src/main/java/com/grepp/teamnotfound/app/controller/api/auth/code/ProviderType.java
+++ b/src/main/java/com/grepp/teamnotfound/app/controller/api/auth/code/ProviderType.java
@@ -1,0 +1,16 @@
+package com.grepp.teamnotfound.app.controller.api.auth.code;
+
+import com.grepp.teamnotfound.infra.error.exception.BusinessException;
+import com.grepp.teamnotfound.infra.error.exception.code.AuthErrorCode;
+
+public enum ProviderType {
+    GOOGLE, KAKAO, NAVER;
+
+    public static ProviderType from(String input){
+        try {
+            return ProviderType.valueOf(input.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new BusinessException(AuthErrorCode.UNSUPPORTED_PROVIDER);
+        }
+    }
+}

--- a/src/main/java/com/grepp/teamnotfound/app/controller/api/auth/payload/LoginResponse.java
+++ b/src/main/java/com/grepp/teamnotfound/app/controller/api/auth/payload/LoginResponse.java
@@ -1,5 +1,6 @@
 package com.grepp.teamnotfound.app.controller.api.auth.payload;
 
+import com.grepp.teamnotfound.app.model.auth.dto.LoginResult;
 import lombok.Builder;
 import lombok.Data;
 
@@ -9,4 +10,11 @@ public class LoginResponse {
 
     private Long userId;
     private TokenResponse tokenResponse;
+
+    public static LoginResponse of(TokenResponse tokenResponse, LoginResult dto) {
+        return LoginResponse.builder()
+                .tokenResponse(tokenResponse)
+                .userId(dto.getUserId())
+                .build();
+    }
 }

--- a/src/main/java/com/grepp/teamnotfound/app/controller/api/auth/payload/TokenResponse.java
+++ b/src/main/java/com/grepp/teamnotfound/app/controller/api/auth/payload/TokenResponse.java
@@ -1,5 +1,6 @@
 package com.grepp.teamnotfound.app.controller.api.auth.payload;
 
+import com.grepp.teamnotfound.app.model.auth.dto.LoginResult;
 import com.grepp.teamnotfound.infra.auth.token.code.GrantType;
 import lombok.Builder;
 import lombok.Data;
@@ -12,5 +13,12 @@ public class TokenResponse {
     private GrantType grantType;
     private Long expiresIn;
 
-
+    public static TokenResponse of(LoginResult result){
+        return TokenResponse.builder()
+                .accessToken(result.getAccessToken())
+                .refreshToken(result.getRefreshToken())
+                .grantType(GrantType.BEARER)
+                .expiresIn(result.getAtExpiresIn())
+                .build();
+    }
 }

--- a/src/main/java/com/grepp/teamnotfound/app/controller/api/report/ReportApiController.java
+++ b/src/main/java/com/grepp/teamnotfound/app/controller/api/report/ReportApiController.java
@@ -25,14 +25,7 @@ public class ReportApiController {
     @Operation(summary = "커뮤니티 게시글/댓글 신고")
     public ResponseEntity<?> createReport(@RequestBody ReportRequest request,
                                           @AuthenticationPrincipal Principal principal) {
-
-        ReportCommand command = ReportCommand.builder()
-                .reporterId(principal.getUserId())
-                .reportType(request.getReportType())
-                .contentId(request.getContentId())
-                .reportCategory(request.getReportCategory())
-                .reason(request.getReason())
-                .build();
+        ReportCommand command = ReportCommand.of(principal, request);
         Long createId = reportService.createReport(command);
         return ResponseEntity.ok(ApiResponse.success(createId));
     }

--- a/src/main/java/com/grepp/teamnotfound/app/model/auth/AuthService.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/auth/AuthService.java
@@ -11,6 +11,7 @@ import com.grepp.teamnotfound.app.model.auth.token.entity.TokenBlackList;
 import com.grepp.teamnotfound.app.model.auth.token.repository.TokenBlackListRepository;
 import com.grepp.teamnotfound.app.model.user.UserService;
 import com.grepp.teamnotfound.app.model.user.entity.User;
+import com.grepp.teamnotfound.app.model.user.repository.UserRepository;
 import com.grepp.teamnotfound.infra.auth.token.JwtProvider;
 import com.grepp.teamnotfound.infra.error.exception.AuthException;
 import com.grepp.teamnotfound.infra.error.exception.code.AuthErrorCode;
@@ -30,15 +31,15 @@ import java.util.Date;
 @RequiredArgsConstructor
 public class AuthService {
 
-    private final UserService userService;
     private final AuthenticationManagerBuilder authenticationManagerBuilder;
     private final JwtProvider jwtProvider;
     private final RefreshTokenService refreshTokenService;
     private final TokenBlackListRepository tokenBlackListRepository;
+    private final UserRepository userRepository;
 
 
     public LoginResult login(LoginCommand request) {
-        User user = userService.findByEmail(request.getEmail())
+        User user = userRepository.findByEmail(request.getEmail())
                 .orElseThrow(() -> new AuthException(UserErrorCode.USER_NOT_FOUND));
 
         if (!user.getRole().isUser()) {
@@ -68,7 +69,7 @@ public class AuthService {
     }
 
     public LoginResult adminLogin(LoginCommand request) {
-        User user = userService.findByEmail(request.getEmail())
+        User user = userRepository.findByEmail(request.getEmail())
                 .orElseThrow(() -> new AuthException(UserErrorCode.USER_NOT_FOUND));
 
         if (!user.getRole().isAdmin()) {

--- a/src/main/java/com/grepp/teamnotfound/app/model/auth/AuthService.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/auth/AuthService.java
@@ -42,6 +42,10 @@ public class AuthService {
         User user = userRepository.findByEmail(request.getEmail())
                 .orElseThrow(() -> new AuthException(UserErrorCode.USER_NOT_FOUND));
 
+        if(user.isDeleted()){
+            throw new AuthException(AuthErrorCode.DELETED_USER);
+        }
+
         if (!user.getRole().isUser()) {
             throw new AuthException(AuthErrorCode.NOT_USER_LOGIN);
         }

--- a/src/main/java/com/grepp/teamnotfound/app/model/auth/AuthService.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/auth/AuthService.java
@@ -37,7 +37,7 @@ public class AuthService {
     private final TokenBlackListRepository tokenBlackListRepository;
     private final UserRepository userRepository;
 
-
+    @Transactional
     public LoginResult login(LoginCommand request) {
         User user = userRepository.findByEmail(request.getEmail())
                 .orElseThrow(() -> new AuthException(UserErrorCode.USER_NOT_FOUND));
@@ -57,7 +57,7 @@ public class AuthService {
         SecurityContextHolder.getContext().setAuthentication(authentication);
 
         TokenDto tokenDto = processTokenLogin(((Principal) authentication.getPrincipal()).getUserId());
-
+        user.updateLastLoginAt();
         return LoginResult.builder()
                 .userId(user.getUserId())
                 .accessToken(tokenDto.getAccessToken())
@@ -68,6 +68,7 @@ public class AuthService {
                 .build();
     }
 
+    @Transactional
     public LoginResult adminLogin(LoginCommand request) {
         User user = userRepository.findByEmail(request.getEmail())
                 .orElseThrow(() -> new AuthException(UserErrorCode.USER_NOT_FOUND));
@@ -87,7 +88,7 @@ public class AuthService {
         SecurityContextHolder.getContext().setAuthentication(authentication);
 
         TokenDto tokenDto = processTokenLogin(((Principal) authentication.getPrincipal()).getUserId());
-
+        user.updateLastLoginAt();
         return LoginResult.builder()
                 .userId(user.getUserId())
                 .accessToken(tokenDto.getAccessToken())

--- a/src/main/java/com/grepp/teamnotfound/app/model/auth/dto/LoginCommand.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/auth/dto/LoginCommand.java
@@ -1,5 +1,6 @@
 package com.grepp.teamnotfound.app.model.auth.dto;
 
+import com.grepp.teamnotfound.app.controller.api.auth.payload.LoginRequest;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -9,5 +10,12 @@ public class LoginCommand {
 
     private String email;
     private String password;
+
+    public static LoginCommand of(LoginRequest request){
+        return LoginCommand.builder()
+                .email(request.getEmail())
+                .password(request.getPassword())
+                .build();
+    }
 
 }

--- a/src/main/java/com/grepp/teamnotfound/app/model/auth/oauth/CustomOAuth2UserService.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/auth/oauth/CustomOAuth2UserService.java
@@ -43,7 +43,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
         // 리소스가 제공하는 유저 정보
         OAuth2User oAuth2User = super.loadUser(userRequest);
 
-        log.info("1️⃣ 리소스가 제공하는 유저 정보 - oAuth2User: {}", oAuth2User);
+        log.info("리소스가 제공하는 유저 정보 - oAuth2User: {}", oAuth2User);
         String registrationId = userRequest.getClientRegistration().getRegistrationId();
 
         OAuth2UserInfo oAuth2UserInfo;
@@ -51,7 +51,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
         // 각 provider별 Info 객체 제작
         if (registrationId.equals("google")) {
             oAuth2UserInfo = new GoogleOAuth2UserInfo(oAuth2User.getAttributes());
-        }else if(registrationId.equals("kakao")){
+        } else if (registrationId.equals("kakao")) {
             oAuth2UserInfo = new KakaoOAuth2UserInfo(oAuth2User.getAttributes());
 
         } else {
@@ -63,7 +63,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
         Optional<User> optionalUser = userRepository.findByEmail(userEmail);
         User user;
         if (optionalUser.isEmpty()) {
-            log.info("2️⃣-1️⃣ 신규 생성되는 유저 email - oAuth2UserInfo.getEmail: {}", oAuth2UserInfo.getEmail());
+            log.info("신규 소셜 가입 요청 유저 email - oAuth2UserInfo.getEmail: {}", oAuth2UserInfo.getEmail());
 
             String tempNickname = generateUniqueNickname();
 
@@ -87,24 +87,35 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
             return new CustomOAuth2UserDto(userDto);
 
-        } else if (Objects.equals(optionalUser.get().getProvider(), oAuth2UserInfo.getProvider())) {
-            log.info("2️⃣-2️⃣ 기존에 존재하는 동일 공급자 email - oAuth2UserInfo.getEmail: {}", oAuth2UserInfo.getEmail());
+        } else {
+            // DB에 해당 email 값이 있는 상황
             user = optionalUser.get();
 
-            // 인증 객체 생성을 위한 dto
-            OAuth2UserDto userDto = OAuth2UserDto.builder()
-                    .email(user.getEmail())
-                    .name(user.getName())
-                    .userId(user.getUserId())
-                    .role("ROLE_USER")
-                    .build();
+            // del 여부 검증
+            if (user.isDeleted()) {
+                log.info("탈퇴한 유저 email - oAuth2UserInfo.getEmail: {}", oAuth2UserInfo.getEmail());
+                OAuth2Error error = new OAuth2Error("DELETED_USER", "탈퇴한 회원입니다.", null);
+                throw new OAuth2AuthenticationException(error, "탈퇴한 회원입니다.");
+            }
 
-            return new CustomOAuth2UserDto(userDto);
+            // provider 검증
+            if (Objects.equals(optionalUser.get().getProvider(), oAuth2UserInfo.getProvider())) {
+                log.info("기존에 동일한 공급자로 가입된 유저 email - oAuth2UserInfo.getEmail: {}", oAuth2UserInfo.getEmail());
 
-        } else {
-            log.info("2️⃣-3️⃣ 기존에 존재하는 다른 공급자 email - oAuth2UserInfo.getEmail: {}", oAuth2UserInfo.getEmail());
-            OAuth2Error error = new OAuth2Error("INVALID_PROVIDER", "다른 provider로 가입된 이메일", null);
-            throw new OAuth2AuthenticationException(error, "다른 provider로 가입된 이메일: " + oAuth2UserInfo.getEmail());
+                // 인증 객체 생성을 위한 dto
+                OAuth2UserDto userDto = OAuth2UserDto.builder()
+                        .email(user.getEmail())
+                        .name(user.getName())
+                        .userId(user.getUserId())
+                        .role("ROLE_USER")
+                        .build();
+
+                return new CustomOAuth2UserDto(userDto);
+            } else {
+                log.info("기존에 다른 공급자로 가입된 유저 email - oAuth2UserInfo.getEmail: {}", oAuth2UserInfo.getEmail());
+                OAuth2Error error = new OAuth2Error("INVALID_PROVIDER", "다른 provider로 가입된 이메일", null);
+                throw new OAuth2AuthenticationException(error, "다른 provider로 가입된 이메일: " + oAuth2UserInfo.getEmail());
+            }
         }
     }
 
@@ -129,7 +140,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
         String dog = dogs[random.nextInt(dogs.length)];
         int num = random.nextInt(10000);
 
-        return adj+dog+num;
+        return adj + dog + num;
     }
 
     public String getAuthUrl(ProviderType provider) {

--- a/src/main/java/com/grepp/teamnotfound/app/model/auth/oauth/CustomOAuth2UserService.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/auth/oauth/CustomOAuth2UserService.java
@@ -1,5 +1,6 @@
 package com.grepp.teamnotfound.app.model.auth.oauth;
 
+import com.grepp.teamnotfound.app.controller.api.auth.code.ProviderType;
 import com.grepp.teamnotfound.app.model.auth.code.Role;
 import com.grepp.teamnotfound.app.model.auth.oauth.dto.CustomOAuth2UserDto;
 import com.grepp.teamnotfound.app.model.auth.oauth.dto.OAuth2UserDto;
@@ -131,7 +132,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
         return adj+dog+num;
     }
 
-    public String getAuthUrl(String provider) {
+    public String getAuthUrl(ProviderType provider) {
         return baseUrl + "/oauth2/authorization/" + provider;
     }
 }

--- a/src/main/java/com/grepp/teamnotfound/app/model/board/entity/Article.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/board/entity/Article.java
@@ -2,6 +2,8 @@ package com.grepp.teamnotfound.app.model.board.entity;
 
 import com.grepp.teamnotfound.app.model.user.entity.User;
 import com.grepp.teamnotfound.infra.entity.BaseEntity;
+import com.grepp.teamnotfound.infra.error.exception.BusinessException;
+import com.grepp.teamnotfound.infra.error.exception.code.ReportErrorCode;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -72,5 +74,11 @@ public class Article extends BaseEntity {
     public void report() {
         this.reportedAt = OffsetDateTime.now();
         super.updatedAt = this.reportedAt;
+    }
+
+    public void isReported(){
+        if(this.reportedAt != null){
+            throw new BusinessException(ReportErrorCode.ALREADY_REPORTED_CONTENTS);
+        }
     }
 }

--- a/src/main/java/com/grepp/teamnotfound/app/model/board/repository/ArticleRepository.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/board/repository/ArticleRepository.java
@@ -42,4 +42,12 @@ public interface ArticleRepository extends JpaRepository<Article, Long>, Article
             where a.articleId = :articleId
             """)
     Optional<Article> findWithBoardByArticleId(@Param("articleId") Long articleId);
+
+    @Query("""
+            select a
+            from Article a
+            join fetch a.user
+            where a.articleId = :articleId
+            """)
+    Optional<Article> findByArticleIdWithWriter(@Param("articleId") Long articleId);
 }

--- a/src/main/java/com/grepp/teamnotfound/app/model/reply/entity/Reply.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/reply/entity/Reply.java
@@ -3,6 +3,8 @@ package com.grepp.teamnotfound.app.model.reply.entity;
 import com.grepp.teamnotfound.app.model.board.entity.Article;
 import com.grepp.teamnotfound.app.model.user.entity.User;
 import com.grepp.teamnotfound.infra.entity.BaseEntity;
+import com.grepp.teamnotfound.infra.error.exception.BusinessException;
+import com.grepp.teamnotfound.infra.error.exception.code.ReportErrorCode;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -61,5 +63,11 @@ public class Reply extends BaseEntity {
     public void report() {
         this.reportedAt = OffsetDateTime.now();
         super.updatedAt = this.reportedAt;
+    }
+
+    public void isReported() {
+        if (this.reportedAt != null) {
+            throw new BusinessException(ReportErrorCode.ALREADY_REPORTED_CONTENTS);
+        }
     }
 }

--- a/src/main/java/com/grepp/teamnotfound/app/model/reply/repository/ReplyRepository.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/reply/repository/ReplyRepository.java
@@ -41,4 +41,12 @@ public interface ReplyRepository extends JpaRepository<Reply, Long> {
     Optional<Reply> findByIdFetchUser(@Param("replyId") Long replyId);
 
     Optional<Reply> findByReplyId(Long replyId);
+
+    @Query("""
+            select r
+            from Reply r
+            join fetch r.user
+            where r.replyId = :replyId
+            """)
+    Optional<Reply> findByReplyIdWithWriter(@Param("replyId") Long replyId);
 }

--- a/src/main/java/com/grepp/teamnotfound/app/model/report/ReportService.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/report/ReportService.java
@@ -45,13 +45,12 @@ public class ReportService {
     }
 
 
+    @Transactional
     public Long createReport(ReportCommand command) {
         User reporter = validateReporter(command.getReporterId());
         User reported = findReportedUser(command.getReportType(), command.getContentId());
 
-        // 스스로 신고 불가
-        validateSelfReport(reporter, reported);
-        // 이미 본인이 신고한 경우 중복 신고 불가
+        reporter.validateNotSelf(reported);
         validateDuplicateReport(reporter, command);
 
         Report report = Report.of(command, reporter, reported);
@@ -63,12 +62,6 @@ public class ReportService {
     private void validateDuplicateReport(User reporter, ReportCommand command) {
         if (reportRepository.duplicateReport(reporter, command.getReportType(), command.getContentId())) {
             throw new BusinessException(ReportErrorCode.DUPLICATED_REPORT);
-        }
-    }
-
-    private void validateSelfReport(User reporter, User reported) {
-        if (reporter.equals(reported)) {
-            throw new BusinessException(ReportErrorCode.CANNOT_REPORT_SELF);
         }
     }
 

--- a/src/main/java/com/grepp/teamnotfound/app/model/report/dto/ReportCommand.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/report/dto/ReportCommand.java
@@ -1,5 +1,7 @@
 package com.grepp.teamnotfound.app.model.report.dto;
 
+import com.grepp.teamnotfound.app.controller.api.report.payload.ReportRequest;
+import com.grepp.teamnotfound.app.model.auth.domain.Principal;
 import com.grepp.teamnotfound.app.model.report.code.ReportCategory;
 import com.grepp.teamnotfound.app.model.report.code.ReportType;
 import lombok.Builder;
@@ -14,4 +16,14 @@ public class ReportCommand {
     private Long contentId;
     private ReportCategory reportCategory;
     private String reason;
+
+    public static ReportCommand of(Principal principal, ReportRequest request) {
+        return ReportCommand.builder()
+                .reporterId(principal.getUserId())
+                .reportType(request.getReportType())
+                .contentId(request.getContentId())
+                .reportCategory(request.getReportCategory())
+                .reason(request.getReason())
+                .build();
+    }
 }

--- a/src/main/java/com/grepp/teamnotfound/app/model/report/repository/ReportRepository.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/report/repository/ReportRepository.java
@@ -22,14 +22,11 @@ public interface ReportRepository extends JpaRepository<Report, Long>, ReportRep
             "and r.contentId = :contentId")
     boolean duplicateReport(@Param("reporter") User reporter, @Param("type") ReportType reportType, @Param("contentId") Long contentId);
 
-    @Query("select r from Report r where r.contentId = :contentId and r.category = :category and r.state = :reportState")
-    List<Report> findByContentIdAndReportCategoryAndState(@Param("contentId") Long contentId, @Param("category") ReportCategory category, @Param("reportState") ReportState reportState);
-
-    @Modifying(flushAutomatically = true, clearAutomatically = true)
-    @Query("update Report r set r.state = :reportState, r.adminReason = :adminReason " +
-            "where r.contentId = :contentId and r.category = :category and r.state = :currentState")
-    void bulkRejectPendingReports(@Param("contentId") Long contentId, @Param("category") ReportCategory category,
-                                 @Param("reportState") ReportState reportState, @Param("adminReason") String adminReason, @Param("currentState") ReportState currentState);
+    @Query("select r from Report r where r.contentId = :contentId and r.category = :category and r.type = :reportType and r.state = :reportState")
+    List<Report> findByContentIdAndReportCategoryAndReportTypeState(@Param("contentId") Long contentId,
+                                                                    @Param("category") ReportCategory category,
+                                                                    @Param("reportType") ReportType type,
+                                                                    @Param("reportState") ReportState reportState);
 
     @Query ("select r " +
             "from Report r " +

--- a/src/main/java/com/grepp/teamnotfound/app/model/user/code/SuspensionPeriod.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/user/code/SuspensionPeriod.java
@@ -13,6 +13,8 @@ public enum SuspensionPeriod {
     SEVEN_DAYS(7),
     FOURTEEN_DAYS(14),
     THIRTY_DAYS(30),
+    THREE_MONTHS(90),
+    ONE_YEAR(365),
     PERMANENT(-1);      // 영구 정지
 
     private final int days;

--- a/src/main/java/com/grepp/teamnotfound/app/model/user/dto/AcceptReportDto.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/user/dto/AcceptReportDto.java
@@ -1,5 +1,6 @@
 package com.grepp.teamnotfound.app.model.user.dto;
 
+import com.grepp.teamnotfound.app.controller.api.admin.payload.AcceptReportRequest;
 import com.grepp.teamnotfound.app.model.user.code.SuspensionPeriod;
 import lombok.Builder;
 import lombok.Getter;
@@ -12,4 +13,11 @@ public class AcceptReportDto {
     private SuspensionPeriod period;
     private String adminReason;
 
+    public static AcceptReportDto of(AcceptReportRequest request){
+        return AcceptReportDto.builder()
+                .reportId(request.getReportId())
+                .period(request.getPeriod())
+                .adminReason(request.getAdminReason())
+                .build();
+    }
 }

--- a/src/main/java/com/grepp/teamnotfound/app/model/user/dto/RegisterCommand.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/user/dto/RegisterCommand.java
@@ -1,5 +1,6 @@
 package com.grepp.teamnotfound.app.model.user.dto;
 
+import com.grepp.teamnotfound.app.controller.api.auth.payload.RegisterRequest;
 import lombok.*;
 
 @Getter
@@ -11,4 +12,13 @@ public class RegisterCommand {
     private final String name;
     private final String nickname;
     private final String password;
+
+    public static RegisterCommand of(RegisterRequest request){
+        return RegisterCommand.builder()
+                .email(request.getEmail())
+                .name(request.getName())
+                .nickname(request.getNickname())
+                .password(request.getPassword())
+                .build();
+    }
 }

--- a/src/main/java/com/grepp/teamnotfound/app/model/user/dto/RejectReportDto.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/user/dto/RejectReportDto.java
@@ -1,5 +1,6 @@
 package com.grepp.teamnotfound.app.model.user.dto;
 
+import com.grepp.teamnotfound.app.controller.api.admin.payload.RejectReportRequest;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -9,4 +10,11 @@ public class RejectReportDto {
 
     private Long reportId;
     private String adminReason;
+
+    public static RejectReportDto of(RejectReportRequest request){
+        return RejectReportDto.builder()
+                .reportId(request.getReportId())
+                .adminReason(request.getAdminReason())
+                .build();
+    }
 }

--- a/src/main/java/com/grepp/teamnotfound/app/model/user/dto/TotalUsersDto.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/user/dto/TotalUsersDto.java
@@ -11,4 +11,10 @@ public class TotalUsersDto {
 
     private OffsetDateTime date;
     private long total;
+
+    public static TotalUsersDto of(long total){
+        return TotalUsersDto.builder()
+                .date(OffsetDateTime.now())
+                .total(total).build();
+    }
 }

--- a/src/main/java/com/grepp/teamnotfound/app/model/user/entity/User.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/user/entity/User.java
@@ -64,6 +64,9 @@ public class User extends BaseEntity {
     @Column
     private OffsetDateTime suspensionEndAt;
 
+    @Column
+    private OffsetDateTime lastLoginAt;
+
 
     public void suspend(SuspensionPeriod period) {
         if (period.isPermanent()) {
@@ -94,5 +97,9 @@ public class User extends BaseEntity {
         if(this.equals(reported)){
             throw new BusinessException(ReportErrorCode.CANNOT_REPORT_SELF);
         }
+    }
+
+    public void updateLastLoginAt() {
+        this.lastLoginAt = OffsetDateTime.now();
     }
 }

--- a/src/main/java/com/grepp/teamnotfound/app/model/user/entity/User.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/user/entity/User.java
@@ -102,4 +102,8 @@ public class User extends BaseEntity {
     public void updateLastLoginAt() {
         this.lastLoginAt = OffsetDateTime.now();
     }
+
+    public boolean isDeleted() {
+        return this.deletedAt != null;
+    }
 }

--- a/src/main/java/com/grepp/teamnotfound/app/model/user/entity/User.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/user/entity/User.java
@@ -4,6 +4,8 @@ import com.grepp.teamnotfound.app.model.auth.code.Role;
 import com.grepp.teamnotfound.app.model.user.code.SuspensionPeriod;
 import com.grepp.teamnotfound.app.model.user.code.UserStateResponse;
 import com.grepp.teamnotfound.infra.entity.BaseEntity;
+import com.grepp.teamnotfound.infra.error.exception.BusinessException;
+import com.grepp.teamnotfound.infra.error.exception.code.ReportErrorCode;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -87,4 +89,10 @@ public class User extends BaseEntity {
         } else
             return UserStateResponse.SUSPENDED;
         }
+
+    public void validateNotSelf(User reported) {
+        if(this.equals(reported)){
+            throw new BusinessException(ReportErrorCode.CANNOT_REPORT_SELF);
+        }
     }
+}

--- a/src/main/java/com/grepp/teamnotfound/app/model/user/entity/User.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/user/entity/User.java
@@ -67,7 +67,7 @@ public class User extends BaseEntity {
 
     public void suspend(SuspensionPeriod period) {
         if (period.isPermanent()) {
-            this.suspensionEndAt = OffsetDateTime.MAX;
+            this.suspensionEndAt = OffsetDateTime.now().plusYears(7777);
             super.updatedAt = OffsetDateTime.now();
             return;
         }

--- a/src/main/java/com/grepp/teamnotfound/app/model/user/repository/UserRepositoryImpl.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/user/repository/UserRepositoryImpl.java
@@ -93,7 +93,7 @@ public class UserRepositoryImpl implements UserRepositoryCustom{
                                         .where(reply.user.userId.eq(user.userId)),
                                 "commentCount"
                         ),
-                        user.createdAt.as("lastLoginDate"),
+                        user.lastLoginAt.as("lastLoginDate"),
                         user.createdAt.as("joinDate"),
                         ExpressionUtils.as(statusExpression, "status"),
                         user.suspensionEndAt
@@ -144,8 +144,8 @@ public class UserRepositoryImpl implements UserRepositoryCustom{
                 Order order = direction.isAsc() ? Order.ASC : Order.DESC;
                 yield new OrderSpecifier<>(order, commentCountQuery);
             }
-            // todo last_login
-            case LAST_LOGIN_DATE -> direction.isAsc() ? user.createdAt.asc() : user.createdAt.desc();
+
+            case LAST_LOGIN_DATE -> direction.isAsc() ? user.lastLoginAt.asc() : user.lastLoginAt.desc();
             case JOIN_DATE -> direction.isAsc() ? user.createdAt.asc() : user.createdAt.desc();
             // 설정
             case SUSPENSION_END_DATE -> direction.isAsc() ? user.suspensionEndAt.asc().nullsLast() : user.suspensionEndAt.desc().nullsLast();

--- a/src/main/java/com/grepp/teamnotfound/infra/auth/oauth2/OAuth2SuccessHandler.java
+++ b/src/main/java/com/grepp/teamnotfound/infra/auth/oauth2/OAuth2SuccessHandler.java
@@ -3,6 +3,7 @@ package com.grepp.teamnotfound.infra.auth.oauth2;
 import com.grepp.teamnotfound.app.model.auth.AuthService;
 import com.grepp.teamnotfound.app.model.auth.oauth.dto.CustomOAuth2UserDto;
 import com.grepp.teamnotfound.app.model.auth.token.dto.TokenDto;
+import com.grepp.teamnotfound.app.model.user.repository.UserRepository;
 import com.grepp.teamnotfound.infra.auth.token.TokenCookieFactory;
 import com.grepp.teamnotfound.infra.auth.token.code.TokenType;
 import jakarta.servlet.ServletException;
@@ -24,6 +25,7 @@ import java.io.IOException;
 public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
     private final AuthService authService;
+    private final UserRepository userRepository;
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
@@ -44,6 +46,11 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         response.addHeader("Set-Cookie", refreshTokenCookie.toString());
 
         log.info("3️⃣ User 회원 로그인: {}", customOAuth2User.getUsername());
+
+        userRepository.findById(userId).ifPresent(user -> {
+            user.updateLastLoginAt();
+            userRepository.save(user);
+        });
 
         // TODO 회원 로그인 후 메인화면(실재 화면 경로)
         getRedirectStrategy().sendRedirect(request, response, "/user/login");

--- a/src/main/java/com/grepp/teamnotfound/infra/error/exception/code/AuthErrorCode.java
+++ b/src/main/java/com/grepp/teamnotfound/infra/error/exception/code/AuthErrorCode.java
@@ -22,7 +22,9 @@ public enum AuthErrorCode implements BaseErrorCode{
     SECURITY_INCIDENT(HttpStatus.UNAUTHORIZED.value(),"AUTH_008","토큰 탈취가 의심됩니다." ),
 
     ALREADY_LOGGED_OUT(HttpStatus.BAD_REQUEST.value(), "AUTH_009", "이미 로그아웃되었습니다."),
-    UNSUPPORTED_PROVIDER(HttpStatus.BAD_REQUEST.value(), "AUTH_010", "지원하지 않는 소셜로그인입니다.");
+    UNSUPPORTED_PROVIDER(HttpStatus.BAD_REQUEST.value(), "AUTH_010", "지원하지 않는 소셜로그인입니다."),
+
+    DELETED_USER(HttpStatus.FORBIDDEN.value(), "AUTH_011", "탈퇴 처리된 사용자입니다.");
 
     private final int status;
     private final String code;

--- a/src/main/java/com/grepp/teamnotfound/infra/error/exception/code/AuthErrorCode.java
+++ b/src/main/java/com/grepp/teamnotfound/infra/error/exception/code/AuthErrorCode.java
@@ -21,7 +21,8 @@ public enum AuthErrorCode implements BaseErrorCode{
     OAUTH_PROVIDER_FAILED(HttpStatus.INTERNAL_SERVER_ERROR.value(), "AUTH_007", "외부 인증 서버와의 호출에 실패했습니다."),
     SECURITY_INCIDENT(HttpStatus.UNAUTHORIZED.value(),"AUTH_008","토큰 탈취가 의심됩니다." ),
 
-    ALREADY_LOGGED_OUT(HttpStatus.BAD_REQUEST.value(), "AUTH_009", "이미 로그아웃되었습니다.");
+    ALREADY_LOGGED_OUT(HttpStatus.BAD_REQUEST.value(), "AUTH_009", "이미 로그아웃되었습니다."),
+    UNSUPPORTED_PROVIDER(HttpStatus.BAD_REQUEST.value(), "AUTH_010", "지원하지 않는 소셜로그인입니다.");
 
     private final int status;
     private final String code;

--- a/src/main/java/com/grepp/teamnotfound/infra/error/exception/code/ReportErrorCode.java
+++ b/src/main/java/com/grepp/teamnotfound/infra/error/exception/code/ReportErrorCode.java
@@ -20,7 +20,8 @@ public enum ReportErrorCode implements BaseErrorCode{
     CANNOT_REPORT_SELF(HttpStatus.BAD_REQUEST.value(), "REPORT_008", "스스로 작성한 콘텐츠는 신고할 수 없습니다."),
 
     ALREADY_COMPLETE_REPORT(HttpStatus.BAD_REQUEST.value(), "REPORT_009", "이미 처리된 신고내역입니다."),
-    ALREADY_COMPLETE_CONTENTS(HttpStatus.BAD_REQUEST.value(), "REPORT_010", "이미 신고 내역이 처리된 콘텐츠입니다.");
+    ALREADY_COMPLETE_CONTENTS(HttpStatus.BAD_REQUEST.value(), "REPORT_010", "이미 신고 내역이 처리된 콘텐츠입니다."),
+    ALREADY_REPORTED_CONTENTS(HttpStatus.BAD_REQUEST.value(), "REPORT_011", "이미 숨김 처리된 콘텐츠입니다.");
 
 
     private final int status;


### PR DESCRIPTION
## ✅ PR 올리기 전에
- [x] `dev`에서 `pull` 받았나요?
- [x] `merge conflict` 발생 시, 해결하고 올리셨나요?
- [x] 자신이 작업한 `changes`만 존재하나요?
- [ ] 작업 중 DB 변경이 발생했나요?

## 🐶 구현한 기능
- 소셜 로그인 미지원 provider 입력 시 예외 처리
- 신고된 report 회원 영구정지 오류 수정 
: OffsetDateTime.MAX 값이 DB 저장이 안 되어서, 현재에 7777년을 더한 값 저장으로 수정했습니다.
- 마지막 로그인 시간 기록 기능 구현
- 탈퇴한 계정 로그인 예외 처리
- 기타 리팩토링

## 🔎 작업 내용

## 📣 공유 사항
- 리팩토링하던 브랜치에 오류 작업도 있었습니다. 양해 부탁드립니다.
