### PR TITLE
feat : 좋아요 개수 조회 API 호출 시 반환값에 좋아요 여부를 추가

### DIFF
--- a/src/main/java/com/grepp/teamnotfound/app/controller/api/article/ArticleApiController.java
+++ b/src/main/java/com/grepp/teamnotfound/app/controller/api/article/ArticleApiController.java
@@ -130,12 +130,17 @@ public class ArticleApiController {
 
     @GetMapping("/v1/{articleId}/like")
     @Operation(summary = "게시글 좋아요 개수")
+    @PreAuthorize("isAnonymous() or isAuthenticated()")
     public ResponseEntity<?> getLikeCount(
-        @PathVariable Long articleId
+        @PathVariable Long articleId,
+        @AuthenticationPrincipal Principal principal
     ) {
-        Integer likeCount = articleService.getActualLikeCount(articleId);
-        return ResponseEntity.ok(ApiResponse.success(Map.of("likes", likeCount)));
-    }
+        Long userId = null;
+        if (principal != null) {
+            userId = principal.getUserId();
+        }
 
-    // TODO 게시글 신고 기능
+        LikeResponse response = articleService.getNewestLikeCount(articleId, userId);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,7 +4,7 @@ upload.path=/tmp/uploads/
 app.domain=http://localhost:8080
 front-server.domain=http://localhost:3000
 
-gemini.api.key={GEMINI_SECRET}
+gemini.api.key=${GEMINI_SECRET}
 
 server.servlet.encoding.charset=UTF-8
 server.servlet.encoding.enabled=true


### PR DESCRIPTION
## ✅ PR 올리기 전에
- [x] `dev`에서 `pull` 받았나요?
- [x] `merge conflict` 발생 시, 해결하고 올리셨나요?
- [x] 자신이 작업한 `changes`만 존재하나요?
- [ ] 작업 중 DB 변경이 발생했나요?

## 🐶 구현한 기능
- 좋아요 개수 조회 API 응답 객체 -> **`isLiked`**(좋아요 여부)를 속성으로 추가

## 🔎 작업 내용
**🚨 기존**
- 단순히 **숫자만** 반환
- DB에서 좋아요 수를 조회하여 반환

**✅ 수정**
- **`LikeResponse`** 객체를 재활용하여 반환
- redis 에 캐시값이 있다면 즉시 반환
- 캐시값이 없거나 false 일 경우 DB에서 조회하여 반환

## 📣 공유 사항
**`GEMINI_SECRET`** 은 main 브랜치에서 수정한 뒤 아직 dev 브랜치에는 반영이 안됐던 것 같아요!
