### PR TITLE
fix : 스케쥴 단일 -> 반복시 단일일정 삭제

### DIFF
--- a/src/main/java/com/grepp/teamnotfound/app/model/schedule/ScheduleService.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/schedule/ScheduleService.java
@@ -123,7 +123,7 @@ public class ScheduleService {
                     continue;
                 }
 
-                schedule.setPet(pet);
+                schedule1.setPet(pet);
                 schedule1.setName(request.getName());
                 schedule1.setScheduleDate(date);
                 schedule1.setCycle(request.getCycle());
@@ -154,6 +154,10 @@ public class ScheduleService {
             // 단독 일정을 반복일정으로 수정 시 추가 일정 생성
             if (!request.getCycle().equals(ScheduleCycle.NONE)) {
                 List<Schedule> schedules = scheduleRepository.findByNameAndCycleAndCycleEnd(schedule.getName(), schedule.getCycle(), schedule.getCycleEnd());
+
+                schedule.setDeletedAt(OffsetDateTime.now());
+                scheduleRepository.save(schedule);
+
                 LocalDate date = request.getDate();
                 for(;date.isBefore(request.getCycleEnd()); date = date.plusDays(request.getCycle().getDays(date))){
                     Schedule addSchedule = Schedule.builder()


### PR DESCRIPTION
## ✅ PR 올리기 전에
- [x] `dev`에서 `pull` 받았나요?
- [x] `merge conflict` 발생 시, 해결하고 올리셨나요?
- [x] 자신이 작업한 `changes`만 존재하나요?
- [ ] 작업 중 DB 변경이 발생했나요?

## 🐶 구현한 기능
스케줄 단일 일정을 반복일정으로 수정 시 단일 일정이 남는 문제를 해결했습니다.

## 🔎 작업 내용


## 📣 공유 사항

