### PR TITLE
feat : redis 연결 예외처리 추가 및 캐시 로직 변경

### DIFF
--- a/src/main/java/com/grepp/teamnotfound/app/model/board/ArticleService.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/board/ArticleService.java
@@ -362,7 +362,7 @@ public class ArticleService {
     private boolean getUserLiked(Long articleId, Long userId) {
         if (userId == null) return false;
         LikeCheckDto checkDto = redisLikeService.isUserLikedInRedis(articleId, userId);
-        if (!checkDto.redisAvailable()) {
+        if (!checkDto.isRedisAvailable()) {
             return articleLikeRepository.existsByArticle_ArticleIdAndUser_UserId(articleId, userId);
         }
         return checkDto.isLiked();

--- a/src/main/java/com/grepp/teamnotfound/app/model/board/RedisLikeService.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/board/RedisLikeService.java
@@ -66,10 +66,9 @@ public class RedisLikeService {
     public void setUserLikedStatus(Long articleId, Long userId, boolean liked) {
         String userLikedKey = "user:liked_status:" + userId + ":" + articleId;
         if (liked) {
-            redisTemplate.opsForValue().set(userLikedKey, "1");
+            redisTemplate.opsForValue().set(userLikedKey, "1"); // 좋아요 상태
         } else {
-            redisTemplate.opsForValue().set(userLikedKey, "0");
-//            redisTemplate.delete(userLikedKey);
+            redisTemplate.opsForValue().set(userLikedKey, "0"); // 좋아요 취소 상태
         }
         redisTemplate.expire(userLikedKey, 7, TimeUnit.DAYS);
     }
@@ -81,14 +80,14 @@ public class RedisLikeService {
             Object value = redisTemplate.opsForValue().get(userLikeStatusKey);
 
             if (value == null) {
-                return new LikeCheckDto(false, false);
+                return new LikeCheckDto(false, false); // 캐시 미스
             } else {
                 boolean isLiked = "1".equals(value.toString());
-                return new LikeCheckDto(isLiked, true);
+                return new LikeCheckDto(isLiked, true); // 캐시 히트
             }
         } catch (Exception e) {
             log.warn("[Redis fallback] isUserLikedInRedis failed - articleId: {}, userId: {}", articleId, userId, e);
-            return new LikeCheckDto(false, false);
+            return new LikeCheckDto(false, false); // 레디스 연결 오류
         }
     }
 

--- a/src/main/java/com/grepp/teamnotfound/app/model/board/RedisLikeService.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/board/RedisLikeService.java
@@ -6,6 +6,7 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataAccessException;
 import org.springframework.data.redis.core.RedisOperations;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -14,19 +15,20 @@ import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class RedisLikeService {
     // TODO Redis 가 다운되었을 경우에 대한 대비 필요
 
     private final RedisTemplate<String, Object> redisTemplate;
 
-    // 배치 대상 article
     private static final String BATCH_ARTICLE_IDS_KEY = "batch:article:ids";
-    // 게시글 총 좋아요 수 카운터 키
     private static final String ARTICLE_LIKES_TOTAL_COUNT_KEY = "article:likes_total_count:";
+    private static final String ARTICLE_LIKE_KEY = "article:like:";
+    private static final String ARTICLE_UNLIKE_KEY = "article:unlike:";
 
     public void addLikeRequest(Long articleId, Long userId) {
-        String likeKey = "article:like:" + articleId;
-        String unlikeKey = "article:unlike:" + articleId;
+        String likeKey = ARTICLE_LIKE_KEY + articleId;
+        String unlikeKey = ARTICLE_UNLIKE_KEY + articleId;
 
         // 반대 요청이 이미 존재하면 제거하고 현재 요청은 무시
         if (Boolean.TRUE.equals(redisTemplate.opsForSet().isMember(unlikeKey, userId))) {
@@ -41,8 +43,8 @@ public class RedisLikeService {
     }
 
     public void addUnlikeRequest(Long articleId, Long userId) {
-        String likeKey = "article:like:" + articleId;
-        String unlikeKey = "article:unlike:" + articleId;
+        String likeKey = ARTICLE_LIKE_KEY + articleId;
+        String unlikeKey = ARTICLE_UNLIKE_KEY + articleId;
 
         // 반대 요청이 이미 존재하면 제거하고 현재 요청은 무시
         if (Boolean.TRUE.equals(redisTemplate.opsForSet().isMember(likeKey, userId))) {
@@ -71,8 +73,13 @@ public class RedisLikeService {
 
     // 사용자의 좋아요 상태를 Redis 에서 확인
     public boolean isUserLikedInRedis(Long articleId, Long userId) {
-        String userLikeStatusKey = "user:liked_status:" + userId + ":" + articleId;
-        return Boolean.TRUE.equals(redisTemplate.hasKey(userLikeStatusKey));
+        try {
+            String userLikeStatusKey = "user:liked_status:" + userId + ":" + articleId;
+            return Boolean.TRUE.equals(redisTemplate.hasKey(userLikeStatusKey));
+        } catch (Exception e) {
+            log.warn("[Redis fallback] isUserLikedInRedis fail - articleId: {}, userId: {}", articleId, userId, e);
+            return false;
+        }
     }
 
 
@@ -89,15 +96,8 @@ public class RedisLikeService {
             @Override
             public <K, V> List<Object> execute(RedisOperations<K, V> operations) throws DataAccessException {
                 operations.multi();
-
-                // Set 의 모든 멤버를 가져옴
-                Set<Object> members = ((RedisTemplate<String, Object>) operations)
-                    .opsForSet()
-                    .members(sourceKey);
-
-                // Set 을 삭제
+                Set<Object> members = ((RedisTemplate<String, Object>) operations).opsForSet().members(sourceKey);
                 ((RedisTemplate<String, Object>) operations).delete(sourceKey);
-
                 return operations.exec();
             }
         });
@@ -111,55 +111,35 @@ public class RedisLikeService {
     }
 
     public Set<Object> getAllLikeRequestsAndClear(Long articleId) {
-        String sourceKey = "article:like:" + articleId;
-
-        List<Object> results = redisTemplate.execute(new SessionCallback<List<Object>>() {
-            @Override
-            public <K, V> List<Object> execute(RedisOperations<K, V> operations) throws DataAccessException {
-
-                operations.multi(); // 트랜잭션 시작
-
-                // 현재 Set 의 모든 멤버를 가져옴
-                Set<Object> members = ((RedisTemplate<String, Object>)operations)
-                    .opsForSet()
-                    .members(sourceKey); // Set 반환
-
-                // 현재 Set 을 삭제
-                ((RedisTemplate<String, Object>)operations).delete(sourceKey); // 삭제된 키의 개수 반환
-
-                return operations.exec(); // 트랜잭션 내의 각 명령을 순서대로 실행
-            }
-        });
-
-        // results 리스트 구조 = [Set<Object>, Long]
-        if (results != null && !results.isEmpty() && results.getFirst() instanceof Set) {
-            return (Set<Object>) results.getFirst();
-        }
-        return Collections.emptySet();
+        return getSetAndClear(ARTICLE_LIKE_KEY + articleId, "getAllLikeRequestsAndClear");
     }
 
     public Set<Object> getAllUnlikeRequestsAndClear(Long articleId) {
-        String sourceKey = "article:unlike:" + articleId;
+        return getSetAndClear(ARTICLE_UNLIKE_KEY + articleId, "getAllUnlikeRequestsAndClear");
+    }
 
-        List<Object> results = redisTemplate.execute(new SessionCallback<List<Object>>() {
-            @Override
-            public <K, V> List<Object> execute(RedisOperations<K, V> operations) throws DataAccessException {
+    private Set<Object> getSetAndClear(String key, String logContext) {
+        try {
+            List<Object> results = redisTemplate.execute(new SessionCallback<List<Object>>() {
+                @Override
+                public <K, V> List<Object> execute(RedisOperations<K, V> operations) throws DataAccessException {
+                    // 트랜잭션 시작
+                    operations.multi();
+                    // Set 반환
+                    Set<Object> members = ((RedisTemplate<String, Object>) operations).opsForSet().members(key);
+                    // 삭제된 키의 개수 반환
+                    ((RedisTemplate<String, Object>) operations).delete(key);
+                    // 트랜잭션 내의 각 명령을 순서대로 실행
+                    return operations.exec();
+                }
+            });
 
-                operations.multi(); // 트랜잭션 시작
-
-                Set<Object> members = ((RedisTemplate<String, Object>) operations)
-                    .opsForSet()
-                    .members(sourceKey); // Set 반환
-
-                ((RedisTemplate<String, Object>) operations).delete(sourceKey); // 삭제된 키의 개수 반환
-
-                return operations.exec(); // 트랜잭션 내의 각 명령을 순서대로 실행
+            // results 리스트 = [Set<Object>, Long]
+            if (results != null && !results.isEmpty() && results.getFirst() instanceof Set) {
+                return (Set<Object>) results.getFirst();
             }
-        });
-
-        // results 리스트 = [Set<Object>, Long]
-        if (results != null && !results.isEmpty() && results.getFirst() instanceof Set) {
-            return (Set<Object>) results.getFirst();
+        } catch (Exception e) {
+            log.error("[Redis fallback] {} fail - key = {}", logContext, key, e);
         }
         return Collections.emptySet();
     }
@@ -171,15 +151,15 @@ public class RedisLikeService {
 
     // Redis 에서 좋아요 카운트 가져오기
     public Long getArticleLikesCount(Long articleId) {
-        String key = ARTICLE_LIKES_TOTAL_COUNT_KEY + articleId;
-        Object count = redisTemplate.opsForValue().get(key);
-        if (count instanceof Integer) {
-            // RedisTemplate 이 Integer 로 저장할 수도 있기 때문
-            return ((Integer) count).longValue();
-        } else if (count instanceof Long) {
-            return (Long) count;
+        try {
+            String key = ARTICLE_LIKES_TOTAL_COUNT_KEY + articleId;
+            Object count = redisTemplate.opsForValue().get(key);
+            if (count instanceof Integer) return ((Integer) count).longValue();
+            if (count instanceof Long) return (Long) count;
+        } catch (Exception e) {
+            log.warn("[Redis fallback] getArticleLikesCount fail - articleId: {}", articleId, e);
         }
-        return null; // 캐시 부재
+        return null;
     }
 
     // Redis 에 좋아요 카운트 설정

--- a/src/main/java/com/grepp/teamnotfound/app/model/board/dto/ArticleLikeDto.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/board/dto/ArticleLikeDto.java
@@ -1,5 +1,0 @@
-package com.grepp.teamnotfound.app.model.board.dto;
-
-public class ArticleLikeDto {
-
-}

--- a/src/main/java/com/grepp/teamnotfound/app/model/board/dto/LikeCheckDto.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/board/dto/LikeCheckDto.java
@@ -1,0 +1,5 @@
+package com.grepp.teamnotfound.app.model.board.dto;
+
+public record LikeCheckDto(boolean isLiked, boolean redisAvailable) {
+
+}

--- a/src/main/java/com/grepp/teamnotfound/app/model/board/dto/LikeCheckDto.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/board/dto/LikeCheckDto.java
@@ -1,5 +1,5 @@
 package com.grepp.teamnotfound.app.model.board.dto;
 
-public record LikeCheckDto(boolean isLiked, boolean redisAvailable) {
+public record LikeCheckDto(boolean isLiked, boolean isRedisAvailable) {
 
 }


### PR DESCRIPTION
## ✅ PR 올리기 전에
- [x] `dev`에서 `pull` 받았나요?
- [x] `merge conflict` 발생 시, 해결하고 올리셨나요?
- [x] 자신이 작업한 `changes`만 존재하나요?
- [ ] 작업 중 DB 변경이 발생했나요?

## 🐶 구현한 기능
- 좋아요 관련 요청 시 **redis 연결 오류**에 대한 예외처리 추가
- 게시글 조회 시 **최신 좋아요 상태** 반환
- 좋아요 취소 상태를 나타내는 **redis key** 추가

## 🔎 작업 내용
- redis 연결 오류가 발생할 경우 좋아요/취소 요청 DB 에 바로 반영
    - (**redis 정상 상태**) : `Client` -> `Redis` -> `Batch Process` -> `DB`
    - (**redis 오류 상태**) : `Client` -> ~`Redis` -> `Batch Process`~ -> `DB`
- 게시글 상세 조회시 최신 업데이트 내역(좋아요 수, 상태) 반환
    - (기존) 회원 좋아요 상태만 저장 "`user:liked_status:userId:articleId:1`"
    - (수정) 회원 좋아요 취소 상태도 값으로 저장 "`user:liked_status:userId:articleId:0`"

