### PR TITLE
feat : 파일용량 예외처리 추가

### DIFF
--- a/src/main/java/com/grepp/teamnotfound/infra/error/exception/advice/GlobalExceptionHandler.java
+++ b/src/main/java/com/grepp/teamnotfound/infra/error/exception/advice/GlobalExceptionHandler.java
@@ -103,7 +103,7 @@ public class GlobalExceptionHandler {
             .body(new ErrorResponse(
                 HttpStatus.PAYLOAD_TOO_LARGE.value(),
                 "PAYLOAD_TOO_LARGE",
-                "파일 크기가 너무 큽니다. 최대 5MB 까지 업로드할 수 있습니다.",
+                "파일 크기가 너무 큽니다. 최대 3MB 까지 업로드할 수 있습니다.",
                 LocalDateTime.now()
             ));
     }

--- a/src/main/java/com/grepp/teamnotfound/infra/error/exception/advice/GlobalExceptionHandler.java
+++ b/src/main/java/com/grepp/teamnotfound/infra/error/exception/advice/GlobalExceptionHandler.java
@@ -21,6 +21,8 @@ import java.time.LocalDateTime;
 import java.util.Objects;
 
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
+import org.springframework.web.multipart.MultipartException;
 
 @Slf4j
 @RestControllerAdvice
@@ -92,5 +94,29 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(HttpStatus.INTERNAL_SERVER_ERROR)
                 .body(response);
+    }
+
+    @ExceptionHandler(MaxUploadSizeExceededException.class)
+    public ResponseEntity<ErrorResponse> handleMaxSizeException(MaxUploadSizeExceededException e) {
+        return ResponseEntity
+            .status(HttpStatus.PAYLOAD_TOO_LARGE)
+            .body(new ErrorResponse(
+                HttpStatus.PAYLOAD_TOO_LARGE.value(),
+                "PAYLOAD_TOO_LARGE",
+                "파일 크기가 너무 큽니다. 최대 5MB 까지 업로드할 수 있습니다.",
+                LocalDateTime.now()
+            ));
+    }
+
+    @ExceptionHandler(MultipartException.class)
+    public ResponseEntity<ErrorResponse> handleMultipartException(MultipartException ex) {
+        return ResponseEntity
+            .status(HttpStatus.BAD_REQUEST)
+            .body(new ErrorResponse(
+                HttpStatus.BAD_REQUEST.value(),
+                "BAD_REQUEST",
+                "파일 업로드 중 오류가 발생했습니다. 파일이나 요청의 형식을 확인해주세요.",
+                LocalDateTime.now()
+            ));
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -77,7 +77,8 @@ springdoc.swagger-ui.try-it-out-enabled=true
 # bucket
 google.cloud.storage.bucket=mungnote-storage
 image.clean.period-days=30
-
+spring.servlet.multipart.max-file-size=5MB
+spring.servlet.multipart.max-request-size=10MB
 
 
 # OAuth2.0

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -77,8 +77,8 @@ springdoc.swagger-ui.try-it-out-enabled=true
 # bucket
 google.cloud.storage.bucket=mungnote-storage
 image.clean.period-days=30
-spring.servlet.multipart.max-file-size=5MB
-spring.servlet.multipart.max-request-size=10MB
+spring.servlet.multipart.max-file-size=3MB
+spring.servlet.multipart.max-request-size=20MB
 
 
 # OAuth2.0


### PR DESCRIPTION
## ✅ PR 올리기 전에
- [x] `dev`에서 `pull` 받았나요?
- [x] `merge conflict` 발생 시, 해결하고 올리셨나요?
- [x] 자신이 작업한 `changes`만 존재하나요?
- [ ] 작업 중 DB 변경이 발생했나요?

## 🐶 구현한 기능
- 파일용량 관련 예외처리 추가

## 🔎 작업 내용
- `application.properties` 에 파일 용량 지정
- `GlobalExceptionHandler` 에 handler 추가
    - 파일 크기 초과 관련 예외
    - 그 외 파일업로드 관련 모든 예외   

## 📣 공유 사항
<img width="585" height="166" alt="image" src="https://github.com/user-attachments/assets/6fa72a9f-ccb5-4436-a541-e27487ae3619" />


