### PR TITLE
fix : 댓글조회 경로 필터 제거 및 좋아요 상태 캐싱 기간 단축

### DIFF
--- a/src/main/java/com/grepp/teamnotfound/app/model/board/ArticleService.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/board/ArticleService.java
@@ -394,27 +394,11 @@ public class ArticleService {
             throw new BoardException(BoardErrorCode.ARTICLE_NOT_FOUND);
         }
 
-        Long likesCount = null;
-        boolean isLiked = false;
-
-        likesCount = redisLikeService.getArticleLikesCount(articleId);
-
-        if (userId != null) {
-            isLiked = getUserLiked(articleId, userId);
-        }
-
-        //  DB 에서 조회가 필요한 경우
-        if (likesCount == null) {
-            Integer dbCount = articleLikeRepository.countByArticle_ArticleId(articleId);
-            likesCount = dbCount.longValue();
-            redisLikeService.setArticleLikesCount(articleId, likesCount);
-        }
-
-        if (!isLiked && userId != null) {
-            isLiked = articleLikeRepository.existsByArticle_ArticleIdAndUser_UserId(articleId, userId);
-        }
-
-        return new LikeResponse(articleId, likesCount.intValue() , isLiked);
+        return new LikeResponse(
+            articleId,
+            getArticleLikeCount(articleId),
+            getUserLiked(articleId, userId)
+        );
     }
 
     @Transactional

--- a/src/main/java/com/grepp/teamnotfound/app/model/board/RedisLikeService.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/board/RedisLikeService.java
@@ -70,7 +70,7 @@ public class RedisLikeService {
         } else {
             redisTemplate.opsForValue().set(userLikedKey, "0"); // 좋아요 취소 상태
         }
-        redisTemplate.expire(userLikedKey, 7, TimeUnit.DAYS);
+        redisTemplate.expire(userLikedKey, 1, TimeUnit.HOURS);
     }
 
     // 사용자의 좋아요 상태를 Redis 에서 확인

--- a/src/main/java/com/grepp/teamnotfound/infra/config/SecurityConfig.java
+++ b/src/main/java/com/grepp/teamnotfound/infra/config/SecurityConfig.java
@@ -76,6 +76,8 @@ public class SecurityConfig {
                         // get 게시글 상세 조회 /api/community/articles/v1/{articleId}
                         // get 게시글 댓글 개수 /api/community/articles/v1/{articleId}/reply
                         .requestMatchers(GET, "/api/community/articles/v1/**").permitAll()
+                        // get 특정 게시글의 댓글 리스트 조회 /api/community/articles/{articleId}/replies/v1
+                        .requestMatchers(GET, "/api/community/articles/*/replies/v1/**").permitAll()
                         // get /api/profile/v1/users/{userId}
                         // get /api/profile/v1/users/{userId}/pet
                         // get /api/profile/v1/users/{userId}/board


### PR DESCRIPTION
## ✅ PR 올리기 전에
- [x] `dev`에서 `pull` 받았나요?
- [x] `merge conflict` 발생 시, 해결하고 올리셨나요?
- [x] 자신이 작업한 `changes`만 존재하나요?
- [ ] 작업 중 DB 변경이 발생했나요?

## 🐶 구현한 기능
- 댓글 조회 경로를 `SecurityConfig` 에 추가
- 좋아요 상태 캐싱 기간 단축 (7일 -> 1시간)
    - 캐싱 기간을 7일로 했을 때 DB가 초기화되면 좋아요 개수가 0개인데도 캐시로 인해 좋아요 상태로 표시되는 문제 
<img width="714" height="419" alt="image" src="https://github.com/user-attachments/assets/9291e3fd-bdb7-426d-9689-b22111f6550c" />
<img width="414" height="248" alt="image" src="https://github.com/user-attachments/assets/f9c0645a-5bc3-46bf-bc9e-7dbbc0791987" />

