### PR TITLE
Fix : 로그아웃 시, 토큰 쿠키 삭제

### DIFF
--- a/src/main/java/com/grepp/teamnotfound/infra/auth/token/filter/LogoutFilter.java
+++ b/src/main/java/com/grepp/teamnotfound/infra/auth/token/filter/LogoutFilter.java
@@ -46,11 +46,21 @@ public class LogoutFilter extends OncePerRequestFilter {
 
             if (accessToken != null) {
                 // 1. 로그아웃 수행
+                log.info("서비스 로그아웃");
                 authService.logout(accessToken);
+
+                log.info("헤더 생성");
+                expiatedCookies(response);
+
                 response.setStatus(HttpStatus.OK.value());
                 response.setContentType(MediaType.APPLICATION_JSON_VALUE);
                 objectMapper.writeValue(response.getWriter(), ApiResponse.success("로그아웃에 성공했습니다."));
             } else {
+
+                log.info("헤더 생성");
+                expiatedCookies(response);
+
+                log.info("이미 로그아웃이므로 ok");
                 response.setStatus(HttpStatus.OK.value());
                 response.setContentType(MediaType.APPLICATION_JSON_VALUE);
                 objectMapper.writeValue(response.getWriter(), ApiResponse.success("이미 로그아웃된 상태입니다."));
@@ -63,15 +73,18 @@ public class LogoutFilter extends OncePerRequestFilter {
         } catch (Exception e) {
             sendLogoutErrorResponse(response, AuthErrorCode.UNAUTHENTICATED, AuthErrorCode.UNAUTHORIZED.getMessage());
         } finally {
-            expiatedCookies(response);
+            log.info("finally 호출");
+//            expiatedCookies(response);
         }
     }
 
     private void expiatedCookies(HttpServletResponse response) {
+        log.info("응답 쿠키 제작 ");
         ResponseCookie expiredAccessToken = TokenCookieFactory.createExpiredToken(TokenType.ACCESS_TOKEN);
         ResponseCookie expiredRefreshToken = TokenCookieFactory.createExpiredToken(TokenType.REFRESH_TOKEN);
         ResponseCookie expiredSessionId = TokenCookieFactory.createExpiredToken(TokenType.AUTH_SERVER_SESSION_ID);
 
+        log.info("헤더에 셋 쿠키");
         response.addHeader("Set-Cookie", expiredAccessToken.toString());
         response.addHeader("Set-Cookie", expiredRefreshToken.toString());
         response.addHeader("Set-Cookie", expiredSessionId.toString());


### PR DESCRIPTION
## ✅ PR 올리기 전에
- [x] `dev`에서 `pull` 받았나요?
- [x] `merge conflict` 발생 시, 해결하고 올리셨나요?
- [x] 자신이 작업한 `changes`만 존재하나요?
- [ ] 작업 중 DB 변경이 발생했나요?

## 🐶 구현한 기능
로그아웃 시, 쿠키의 유효시간 만료만 시키고, 쿠키에서 삭제를 못 하고 있어서,
유효기간 만료된 토큰을 들고 있는 사용자는 401(유효기간 만료 토큰으로 인한 사용자 인증 실패)로 뭐든 안 되고 있었습니다.
쿠키 삭제 로직 위치를 finally보다 위로 옮겼더니 작동이 됩니다.

## 🔎 작업 내용


## 📣 공유 사항

