### PR TITLE
Fix : 소셜 로그인 실패 시 redirect url 경로 변경 및 로컬 provider 가입 계정 error 메시지 분기

### DIFF
--- a/src/main/java/com/grepp/teamnotfound/app/model/auth/oauth/CustomOAuth2UserService.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/auth/oauth/CustomOAuth2UserService.java
@@ -111,6 +111,10 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
                         .build();
 
                 return new CustomOAuth2UserDto(userDto);
+            } else if(Objects.equals(optionalUser.get().getProvider(), "local")) {
+                log.info("로컬로 가입된 유저 email - oAuth2UserInfo.getEmail: {}", oAuth2UserInfo.getEmail());
+                OAuth2Error error = new OAuth2Error("INVALID_PROVIDER", "멍멍일지로 가입된 이메일", null);
+                throw new OAuth2AuthenticationException(error, "멍멍일지로 가입된 이메일: " + oAuth2UserInfo.getEmail());
             } else {
                 log.info("기존에 다른 공급자로 가입된 유저 email - oAuth2UserInfo.getEmail: {}", oAuth2UserInfo.getEmail());
                 OAuth2Error error = new OAuth2Error("INVALID_PROVIDER", "다른 provider로 가입된 이메일", null);

--- a/src/main/java/com/grepp/teamnotfound/infra/auth/oauth2/OAuth2FailureHandler.java
+++ b/src/main/java/com/grepp/teamnotfound/infra/auth/oauth2/OAuth2FailureHandler.java
@@ -26,7 +26,7 @@ public class OAuth2FailureHandler extends SimpleUrlAuthenticationFailureHandler 
 
         String errorMessage;
         if (exception.getMessage().contains("다른 provider로 가입된 이메일")) {
-            errorMessage = "이미 다른 계정으로 가입된 이메일입니다.";
+            errorMessage = "이미 다른 소셜 계정으로 가입된 이메일입니다.";
         } else if (exception.getMessage().contains("지원하지 않는 OAuth2 provider")) {
             errorMessage = "지원하지 않는 소셜 로그인입니다.";
         } else if(exception.getMessage().contains("멍멍일지")){

--- a/src/main/java/com/grepp/teamnotfound/infra/auth/oauth2/OAuth2FailureHandler.java
+++ b/src/main/java/com/grepp/teamnotfound/infra/auth/oauth2/OAuth2FailureHandler.java
@@ -29,12 +29,14 @@ public class OAuth2FailureHandler extends SimpleUrlAuthenticationFailureHandler 
             errorMessage = "이미 다른 계정으로 가입된 이메일입니다.";
         } else if (exception.getMessage().contains("지원하지 않는 OAuth2 provider")) {
             errorMessage = "지원하지 않는 소셜 로그인입니다.";
+        } else if(exception.getMessage().contains("멍멍일지")){
+            errorMessage = "멍멍일지로 가입된 이메일입니다. 멍멍일지 로그인을 시도해주세요.";
         }
         else {
             errorMessage = "소셜 로그인에 실패했습니다.";
         }
 
-        String failRedirectUri = "/error/login?error=" + URLEncoder.encode(errorMessage, StandardCharsets.UTF_8);
+        String failRedirectUri = "https://mungnote.vercel.app/login?error=" + URLEncoder.encode(errorMessage, StandardCharsets.UTF_8);
 
         getRedirectStrategy().sendRedirect(request, response, failRedirectUri);
     }


### PR DESCRIPTION
## ✅ PR 올리기 전에
- [x] `dev`에서 `pull` 받았나요?
- [x] `merge conflict` 발생 시, 해결하고 올리셨나요?
- [x] 자신이 작업한 `changes`만 존재하나요?
- [ ] 작업 중 DB 변경이 발생했나요?

## 🐶 구현한 기능
실패 시 리다이렉트를 상대경로로 보내고 있어서, 다른 곳으로 가고 있었습니다.
더불어 프론트에서 local provider일 경우 메시지 분기 요청하여 해당 사항까지 변경하였습니다.

## 🔎 작업 내용


## 📣 공유 사항

