### PR TITLE
Refactor: 동일 조건의 Recommend 1개만 존재하도록 제약조건 추가

### DIFF
--- a/src/main/java/com/grepp/teamnotfound/app/model/recommend/entity/Recommend.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/recommend/entity/Recommend.java
@@ -15,12 +15,21 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.Getter;
 import lombok.Setter;
 
 
 @Entity
-@Table(name = "Recommends")
+@Table(
+    name = "Recommends",
+    uniqueConstraints = {
+        @UniqueConstraint(
+            name = "uq_recommend_criteria",
+            columnNames = {"age", "breed", "size", "weightState", "walkingState", "sleepingState"}
+        )
+    }
+)
 @Getter
 @Setter
 public class Recommend extends BaseEntity {


### PR DESCRIPTION
## ✅ PR 올리기 전에
- [x] `dev`에서 `pull` 받았나요?
- [x] `merge conflict` 발생 시, 해결하고 올리셨나요?
- [x] 자신이 작업한 `changes`만 존재하나요?
- [x] 작업 중 DB 변경이 발생했나요?

## 🐶 구현한 기능
- 동시에 같은 조건의 Recommend가 등록될 때 1개만 DB에 저장되도록 제약조건 추가

## 📣 공유 사항
- 이전에 올린 synchronized 방법은 차례대로 처리하여 시간적으로 효율적이지 않아서 이 방법 사용