### PR TITLE
Refactor : 신고 처리와 처리 결과 알림 서비스 분리

### DIFF
--- a/src/main/java/com/grepp/teamnotfound/app/controller/api/admin/AdminController.java
+++ b/src/main/java/com/grepp/teamnotfound/app/controller/api/admin/AdminController.java
@@ -7,6 +7,7 @@ import com.grepp.teamnotfound.app.model.board.dto.YearlyArticlesStatsDto;
 import com.grepp.teamnotfound.app.model.report.ReportService;
 import com.grepp.teamnotfound.app.model.report.dto.ReportDetailDto;
 import com.grepp.teamnotfound.app.model.report.dto.ReportsListDto;
+import com.grepp.teamnotfound.app.model.report.entity.Report;
 import com.grepp.teamnotfound.app.model.user.AdminService;
 import com.grepp.teamnotfound.app.model.user.dto.*;
 import io.swagger.v3.oas.annotations.Operation;
@@ -121,7 +122,8 @@ public class AdminController {
     @PatchMapping("v1/reports/result-accept")
     public ResponseEntity<?> acceptReport(@RequestBody AcceptReportRequest request){
         AcceptReportDto dto = AcceptReportDto.of(request);
-        adminService.acceptReportAndSuspendUser(dto);
+        List<Report> reports = adminService.acceptReportAndSuspendUser(dto);
+        adminService.notiAccept(reports);
         return ResponseEntity.ok("신고가 정상적으로 처리되었습니다.");
     }
 
@@ -129,7 +131,8 @@ public class AdminController {
     @PatchMapping("v1/reports/result-reject")
     public ResponseEntity<?> rejectReport(@RequestBody RejectReportRequest request){
         RejectReportDto dto = RejectReportDto.of(request);
-        adminService.rejectReport(dto);
+        List<Report> reports = adminService.rejectReport(dto);
+        adminService.notiReject(reports);
         return ResponseEntity.ok("신고를 성공적으로 거절하였습니다.");
     }
 

--- a/src/main/java/com/grepp/teamnotfound/app/model/user/AdminService.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/user/AdminService.java
@@ -158,13 +158,6 @@ public class AdminService {
         Report targetReport = reportRepository.findByReportIdWithUsers(dto.getReportId())
                 .orElseThrow(() -> new BusinessException(ReportErrorCode.REPORT_NOT_FOUND));
 
-        targetReport.reject(dto.getAdminReason());
-
-        NotiServiceCreateDto notiDto1 = NotiServiceCreateDto.builder()
-            .targetId(targetReport.getReportId())
-            .build();
-        notiAppender.append(targetReport.getReporter().getUserId(), NotiType.REPORT_FAIL, notiDto1);
-
         List<Report> reports = reportRepository.findByContentIdAndReportCategoryAndReportTypeState(
                 targetReport.getContentId(),
                 targetReport.getCategory(),
@@ -187,13 +180,6 @@ public class AdminService {
                 .orElseThrow(() -> new BusinessException(ReportErrorCode.REPORT_NOT_FOUND));
 
         hideContentBy(targetReport);
-        targetReport.accept(dto.getAdminReason());
-
-        NotiServiceCreateDto notiDto1 = NotiServiceCreateDto.builder()
-            .targetId(targetReport.getReportId())
-            .build();
-        notiAppender.append(targetReport.getReporter().getUserId(), NotiType.REPORT_SUCCESS, notiDto1);
-        notiAppender.append(targetReport.getReported().getUserId(), NotiType.REPORTED, notiDto1);
 
         List<Report> reports = reportRepository.findByContentIdAndReportCategoryAndReportTypeState(
                 targetReport.getContentId(),

--- a/src/main/java/com/grepp/teamnotfound/app/model/user/AdminService.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/user/AdminService.java
@@ -186,7 +186,7 @@ public class AdminService {
         Report targetReport = reportRepository.findByReportIdWithUsers(dto.getReportId())
                 .orElseThrow(() -> new BusinessException(ReportErrorCode.REPORT_NOT_FOUND));
 
-        insertReportedAtOfContent(targetReport);
+        hideContentBy(targetReport);
         targetReport.accept(dto.getAdminReason());
 
         NotiServiceCreateDto notiDto1 = NotiServiceCreateDto.builder()
@@ -215,7 +215,7 @@ public class AdminService {
         user.suspend(dto.getPeriod());
     }
 
-    private void insertReportedAtOfContent(Report targetReport) {
+    private void hideContentBy(Report targetReport) {
         if(targetReport.getType() == ReportType.BOARD){
             Article article = articleRepository.findByArticleId(targetReport.getContentId())
                     .orElseThrow(() -> new BusinessException(BoardErrorCode.ARTICLE_NOT_FOUND));

--- a/src/main/java/com/grepp/teamnotfound/app/model/user/AdminService.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/user/AdminService.java
@@ -154,7 +154,7 @@ public class AdminService {
     }
 
     @Transactional
-    public void rejectReport(RejectReportDto dto) {
+    public List<Report> rejectReport(RejectReportDto dto) {
         Report targetReport = reportRepository.findByReportIdWithUsers(dto.getReportId())
                 .orElseThrow(() -> new BusinessException(ReportErrorCode.REPORT_NOT_FOUND));
 
@@ -166,7 +166,12 @@ public class AdminService {
         );
         for (Report report : reports) {
             report.reject(dto.getAdminReason());
+        }
+        return reports;
+    }
 
+    public void notiReject(List<Report> reports){
+        for (Report report : reports) {
             NotiServiceCreateDto notiDtos = NotiServiceCreateDto.builder()
                 .targetId(report.getReportId())
                 .build();
@@ -175,7 +180,7 @@ public class AdminService {
     }
 
     @Transactional
-    public void acceptReportAndSuspendUser(AcceptReportDto dto) {
+    public List<Report> acceptReportAndSuspendUser(AcceptReportDto dto) {
         Report targetReport = reportRepository.findByReportIdWithUsers(dto.getReportId())
                 .orElseThrow(() -> new BusinessException(ReportErrorCode.REPORT_NOT_FOUND));
 
@@ -189,16 +194,22 @@ public class AdminService {
         );
         for (Report report : reports) {
             report.accept(dto.getAdminReason());
-
-            NotiServiceCreateDto notiDtos = NotiServiceCreateDto.builder()
-                .targetId(report.getReportId())
-                .build();
-            notiAppender.append(report.getReporter().getUserId(), NotiType.REPORT_SUCCESS, notiDtos);
-            notiAppender.append(report.getReported().getUserId(), NotiType.REPORTED, notiDtos);
         }
 
         User user = targetReport.getReported();
         user.suspend(dto.getPeriod());
+
+        return reports;
+    }
+
+    public void notiAccept(List<Report> reports) {
+        for(Report report : reports) {
+            NotiServiceCreateDto notiDtos = NotiServiceCreateDto.builder()
+                    .targetId(report.getReportId())
+                    .build();
+            notiAppender.append(report.getReporter().getUserId(), NotiType.REPORT_SUCCESS, notiDtos);
+            notiAppender.append(report.getReported().getUserId(), NotiType.REPORTED, notiDtos);
+        }
     }
 
     private void hideContentBy(Report targetReport) {


### PR DESCRIPTION
## ✅ PR 올리기 전에
- [x] `dev`에서 `pull` 받았나요?
- [x] `merge conflict` 발생 시, 해결하고 올리셨나요?
- [x] 자신이 작업한 `changes`만 존재하나요?
- [ ] 작업 중 DB 변경이 발생했나요?

## 🔎 작업 내용
- 신고 처리와 처리 결과에 대한 알림이 한 트랜잭션 안에 있어서,
for문 내 알림 실패 시, 이전 처리 결과 알림이 발송된 경우의 DB도 롤백되어 정보가 불일치할 가능성이 있었습니다.
이에 해당 서비스 로직을 분리하였습니다.
- 겸사겸사 불필요하게 targetReport를 처리하던 걸 지웠습니다.
- 성능상 이전이 더 낫지만, 보수적으로 접근하여 수정했습니다.