### PR TITLE
Refactor: 좋아요 요청 동시성 해결 및 배치 처리 로직 개선

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -72,6 +72,7 @@ dependencies {
     implementation 'nz.net.ultraq.thymeleaf:thymeleaf-layout-dialect'
     implementation 'org.webjars:bootstrap:5.3.7'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.redisson:redisson-spring-boot-starter:3.31.0'
 
     implementation 'org.springframework.security:spring-security-oauth2-client'
     implementation 'org.springframework.security:spring-security-oauth2-jose'

--- a/src/main/java/com/grepp/teamnotfound/app/model/board/LikeBatchProcessor.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/board/LikeBatchProcessor.java
@@ -43,7 +43,7 @@ public class LikeBatchProcessor {
 
     // 좋아요 관련 요청을 DB에 반영
     public void syncLikesWithDB() {
-        Set<Long> changedArticleIds = redisLikeService.getAllChangedArticleIdsAndClear();
+        Set<Long> changedArticleIds = redisLikeService.getAllChangedArticleIds();
 
         if (changedArticleIds.isEmpty()) {
             log.info("No changed article found. Skipping batch processing.");
@@ -54,7 +54,7 @@ public class LikeBatchProcessor {
             try {
                 likeService.syncOneArticleLikes(articleId);
             } catch (Exception e) {
-                log.error("Failed to sync likes for articleId: {}", articleId);
+                log.error("Failed to sync likes for articleId: {}. Retrying on next batch.", articleId, e);
             }
         }
 

--- a/src/main/java/com/grepp/teamnotfound/app/model/board/LikeBatchProcessor.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/board/LikeBatchProcessor.java
@@ -1,20 +1,13 @@
 package com.grepp.teamnotfound.app.model.board;
 
-import com.grepp.teamnotfound.app.model.board.entity.ArticleLike;
-import com.grepp.teamnotfound.app.model.board.repository.ArticleLikeRepository;
-import com.grepp.teamnotfound.app.model.board.repository.ArticleRepository;
-import com.grepp.teamnotfound.app.model.notification.code.NotiType;
-import com.grepp.teamnotfound.app.model.notification.dto.NotiServiceCreateDto;
-import com.grepp.teamnotfound.app.model.notification.handler.NotiAppender;
-import com.grepp.teamnotfound.app.model.user.repository.UserRepository;
-import java.time.OffsetDateTime;
-import java.util.List;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
 @Component
 @RequiredArgsConstructor
@@ -22,18 +15,34 @@ import org.springframework.transaction.annotation.Transactional;
 public class LikeBatchProcessor {
 
     private final RedisLikeService redisLikeService;
-    private final ArticleRepository articleRepository;
-    private final ArticleLikeRepository articleLikeRepository;
-    private final UserRepository userRepository;
-    private final NotiAppender notiAppender;
+    private final LikeService likeService;
+    private final RedissonClient redissonClient;
+    private static final String BATCH_LOCK_KEY = "lock:like_batch_processor";
 
     // 1분마다 실행
     @Scheduled(fixedDelay = 60000)
-    @Transactional
     public void processLikeBatch() {
-        log.info("Processing likes batch...");
+        RLock lock = redissonClient.getLock(BATCH_LOCK_KEY);
+        try {
+            boolean isLocked = lock.tryLock(10, 55, TimeUnit.SECONDS);
 
-        // 요청이 들어온 articleId 리스트
+            if (isLocked) {
+                log.info("Acquired lock. Starting likes batch processing...");
+                syncLikesWithDB();
+            }
+
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        } finally {
+            if (lock.isHeldByCurrentThread()) {
+                lock.unlock();
+                log.info("Lock released");
+            }
+        }
+    }
+
+    // 좋아요 관련 요청을 DB에 반영
+    public void syncLikesWithDB() {
         Set<Long> changedArticleIds = redisLikeService.getAllChangedArticleIdsAndClear();
 
         if (changedArticleIds.isEmpty()) {
@@ -42,60 +51,11 @@ public class LikeBatchProcessor {
         }
 
         for (Long articleId : changedArticleIds) {
-            Set<Object> likeRequests = redisLikeService.getAllLikeRequestsAndClear(articleId);
-            Set<Object> unlikeRequests = redisLikeService.getAllUnlikeRequestsAndClear(articleId);
-
-            // 요청 송신자 userId 리스트
-            List<Long> usersToLike = likeRequests.stream()
-                .map(object -> Long.valueOf(object.toString()))
-                .toList();
-
-            List<Long> usersToUnlike = unlikeRequests.stream()
-                .map(object -> Long.valueOf(object.toString()))
-                .toList();
-
-            // 좋아요를 한꺼번에 INSERT
-            // NOTE 단순 반복문을 사용하면 너무 잦은 I/O 로 Redis 를 도입한 장점이 사라짐
-            if (!usersToLike.isEmpty()) {
-                List<Long> alreadyLiked = articleLikeRepository.findUserIdsByArticleId(articleId);
-
-                List<ArticleLike> likesToInsert = usersToLike.stream()
-                    .filter(userId -> !alreadyLiked.contains(userId))
-                    .map(userId -> ArticleLike.builder()
-                        .article(articleRepository.getReferenceById(articleId))
-                        .user(userRepository.getReferenceById(userId))
-                        .createdAt(OffsetDateTime.now())
-                        .build()
-                    ).toList();
-
-                articleLikeRepository.saveAll(likesToInsert);
-
-                for (ArticleLike like : likesToInsert) {
-                    Long senderId = like.getUser().getUserId();
-                    Long receiverId = like.getArticle().getUser().getUserId();
-                    Long targetId = like.getLikeId();
-
-                    if (!senderId.equals(receiverId)) {
-                        NotiServiceCreateDto dto = NotiServiceCreateDto.builder()
-                            .targetId(targetId)
-                            .notiType(NotiType.LIKE)
-                            .build();
-
-                        notiAppender.append(receiverId, NotiType.LIKE, dto);
-                    }
-                }
+            try {
+                likeService.syncOneArticleLikes(articleId);
+            } catch (Exception e) {
+                log.error("Failed to sync likes for articleId: {}", articleId);
             }
-
-            // 좋아요를 한꺼번에 DELETE
-            if (!usersToUnlike.isEmpty()) {
-                // NOTE 나중에 성능이 안나온다면 JPQL 쿼리로 직접 DELETE 쿼리 날려보기
-                List<ArticleLike> likesToDelete = articleLikeRepository.findAllByArticleIdAndUserIds(articleId, usersToUnlike);
-                articleLikeRepository.deleteAllInBatch(likesToDelete);
-            }
-
-            // DB 에 최종 반영된 좋아요 수를 가져와 Redis 캐시를 업데이트하여 정합성 유지
-            Integer finalDbLikeCount = articleLikeRepository.countByArticle_ArticleId(articleId);
-            redisLikeService.setArticleLikesCount(articleId, finalDbLikeCount.longValue());
         }
 
         log.info("Likes batch processing finished for {} articles.", changedArticleIds.size());

--- a/src/main/java/com/grepp/teamnotfound/app/model/board/LikeService.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/board/LikeService.java
@@ -1,0 +1,86 @@
+package com.grepp.teamnotfound.app.model.board;
+
+import com.grepp.teamnotfound.app.model.board.entity.ArticleLike;
+import com.grepp.teamnotfound.app.model.board.repository.ArticleLikeRepository;
+import com.grepp.teamnotfound.app.model.board.repository.ArticleRepository;
+import com.grepp.teamnotfound.app.model.notification.code.NotiType;
+import com.grepp.teamnotfound.app.model.notification.dto.NotiServiceCreateDto;
+import com.grepp.teamnotfound.app.model.notification.handler.NotiAppender;
+import com.grepp.teamnotfound.app.model.user.repository.UserRepository;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class LikeService {
+
+    private final ArticleRepository articleRepository;
+    private final ArticleLikeRepository articleLikeRepository;
+    private final UserRepository userRepository;
+    private final RedisLikeService redisLikeService;
+    private final NotiAppender notiAppender;
+
+    // articleId 별로 좋아요 처리 트랜잭션을 분리
+    @Transactional
+    public void syncOneArticleLikes(Long articleId) {
+        Set<Object> likeRequests = redisLikeService.getAllLikeRequestsAndClear(articleId);
+        Set<Object> unlikeRequests = redisLikeService.getAllUnlikeRequestsAndClear(articleId);
+
+        // 요청 송신자 userId 리스트
+        List<Long> usersToLike = likeRequests.stream()
+            .map(object -> Long.valueOf(object.toString()))
+            .toList();
+
+        List<Long> usersToUnlike = unlikeRequests.stream()
+            .map(object -> Long.valueOf(object.toString()))
+            .toList();
+
+        if (!usersToLike.isEmpty()) {
+            List<Long> alreadyLiked = articleLikeRepository.findUserIdsByArticleId(articleId);
+
+            List<ArticleLike> likesToInsert = usersToLike.stream()
+                .filter(userId -> !alreadyLiked.contains(userId))
+                .map(userId -> ArticleLike.builder()
+                    .article(articleRepository.getReferenceById(articleId))
+                    .user(userRepository.getReferenceById(userId))
+                    .createdAt(OffsetDateTime.now())
+                    .build()
+                ).toList();
+
+            articleLikeRepository.saveAll(likesToInsert);
+
+            for (ArticleLike like : likesToInsert) {
+                Long senderId = like.getUser().getUserId();
+                Long receiverId = like.getArticle().getUser().getUserId();
+                Long targetId = like.getLikeId();
+
+                if (!senderId.equals(receiverId)) {
+                    NotiServiceCreateDto dto = NotiServiceCreateDto.builder()
+                        .targetId(targetId)
+                        .notiType(NotiType.LIKE)
+                        .build();
+
+                    notiAppender.append(receiverId, NotiType.LIKE, dto);
+                }
+            }
+        }
+
+        // 좋아요를 한꺼번에 DELETE
+        if (!usersToUnlike.isEmpty()) {
+            // NOTE 나중에 성능이 안나온다면 JPQL 쿼리로 직접 DELETE 쿼리 날려보기
+            List<ArticleLike> likesToDelete = articleLikeRepository.findAllByArticleIdAndUserIds(
+                articleId, usersToUnlike);
+            articleLikeRepository.deleteAllInBatch(likesToDelete);
+        }
+
+        // DB 에 최종 반영된 좋아요 수를 가져와 Redis 캐시를 업데이트하여 정합성 유지
+        Integer finalDbLikeCount = articleLikeRepository.countByArticle_ArticleId(articleId);
+        redisLikeService.setArticleLikesCount(articleId, finalDbLikeCount.longValue());
+    }
+}

--- a/src/main/java/com/grepp/teamnotfound/app/model/board/LikeService.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/board/LikeService.java
@@ -29,8 +29,8 @@ public class LikeService {
     // articleId 별로 좋아요 처리 트랜잭션을 분리
     @Transactional
     public void syncOneArticleLikes(Long articleId) {
-        Set<Object> likeRequests = redisLikeService.getAllLikeRequestsAndClear(articleId);
-        Set<Object> unlikeRequests = redisLikeService.getAllUnlikeRequestsAndClear(articleId);
+        Set<Object> likeRequests = redisLikeService.getAllLikeRequests(articleId);
+        Set<Object> unlikeRequests = redisLikeService.getAllUnlikeRequests(articleId);
 
         // 요청 송신자 userId 리스트
         List<Long> usersToLike = likeRequests.stream()
@@ -82,5 +82,10 @@ public class LikeService {
         // DB 에 최종 반영된 좋아요 수를 가져와 Redis 캐시를 업데이트하여 정합성 유지
         Integer finalDbLikeCount = articleLikeRepository.countByArticle_ArticleId(articleId);
         redisLikeService.setArticleLikesCount(articleId, finalDbLikeCount.longValue());
+
+        // 모든 DB 작업이 성공하면 Redis 데이터 삭제
+        redisLikeService.clearLikeRequests(articleId);
+        redisLikeService.clearUnlikeRequests(articleId);
+        redisLikeService.clearChangedArticleId(articleId);
     }
 }

--- a/src/main/java/com/grepp/teamnotfound/app/model/board/RedisLikeService.java
+++ b/src/main/java/com/grepp/teamnotfound/app/model/board/RedisLikeService.java
@@ -165,6 +165,62 @@ public class RedisLikeService {
     }
 
     /**
+     * Batch 처리용 - 조회
+     * Redis 에서 요청을 가져오기만 하고 삭제하지 않는 메서드
+     **/
+
+    // 좋아요/취소 요청을 받은 articleId 반환
+    public Set<Long> getAllChangedArticleIds() {
+        try {
+            Set<Object> members = redisTemplate.opsForSet().members(BATCH_ARTICLE_IDS_KEY);
+            if (members != null) {
+                return members.stream()
+                    .map(object -> Long.valueOf(object.toString()))
+                    .collect(Collectors.toSet());
+            }
+        } catch (Exception e) {
+            log.error("[Redis fallback] getAllChangedArticleIds failed");
+        }
+        return Collections.emptySet();
+    }
+
+    public Set<Object> getAllLikeRequests(Long articleId) {
+        return getSet(ARTICLE_LIKE_KEY + articleId, "getAllLikeRequests");
+    }
+
+    public Set<Object> getAllUnlikeRequests(Long articleId) {
+        return getSet(ARTICLE_UNLIKE_KEY + articleId, "getAllUnlikeRequests");
+    }
+
+    private Set<Object> getSet(String key, String logText) {
+        try {
+            Set<Object> members = redisTemplate.opsForSet().members(key);
+            if (members != null) {
+                return members;
+            }
+        } catch (Exception e) {
+            log.error("[Redis fallback] {} failed - key = {}", logText, key, e);
+        }
+        return Collections.emptySet();
+    }
+
+    /**
+     * Batch 처리용 - 삭제
+     * DB 트랜잭션 성공 후 Redis 데이터를 삭제하는 메서드
+     **/
+    public void clearChangedArticleId(Long articleId) {
+        redisTemplate.opsForSet().remove(BATCH_ARTICLE_IDS_KEY, articleId);
+    }
+
+    public void clearLikeRequests(Long articleId) {
+        redisTemplate.delete(ARTICLE_LIKE_KEY + articleId);
+    }
+
+    public void clearUnlikeRequests(Long articleId) {
+        redisTemplate.delete(ARTICLE_UNLIKE_KEY + articleId);
+    }
+
+    /**
      * 게시글별 좋아요 수 캐시용
      * 좋아요/좋아요 취소 요청 시 최종 좋아요 수를 계산하기 위한 IO를 줄이기 위함
      * */

--- a/src/main/java/com/grepp/teamnotfound/infra/config/RedissonConfig.java
+++ b/src/main/java/com/grepp/teamnotfound/infra/config/RedissonConfig.java
@@ -1,0 +1,35 @@
+package com.grepp.teamnotfound.infra.config;
+
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RedissonConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Value("${spring.data.redis.username}")
+    private String username;
+
+    @Value("${spring.data.redis.password}")
+    private String password;
+
+    @Bean
+    public RedissonClient redissonClient() {
+        Config config = new Config();
+
+        config.useSingleServer().setAddress("redis://" + host + ":" + port);
+        config.useSingleServer().setPassword(password);
+        config.useSingleServer().setUsername(username);
+
+        return Redisson.create(config);
+    }
+}

--- a/src/main/resources/db/migration/V5__article_index.sql
+++ b/src/main/resources/db/migration/V5__article_index.sql
@@ -1,0 +1,7 @@
+CREATE INDEX idx_articles_board_deleted_reported_created ON public.articles (board_id, deleted_at, reported_at, created_at DESC);
+
+CREATE INDEX idx_replies_article_deleted_reported ON public.replies (article_id, deleted_at, reported_at);
+
+CREATE INDEX idx_article_imgs_article_type_deleted ON public.article_imgs (article_id, type, deleted_at);
+
+CREATE INDEX idx_article_likes_article_id ON public.article_likes (article_id);

--- a/src/test/java/com/grepp/teamnotfound/app/model/report/ReportServiceTest.java
+++ b/src/test/java/com/grepp/teamnotfound/app/model/report/ReportServiceTest.java
@@ -9,7 +9,8 @@ import com.grepp.teamnotfound.app.model.report.code.ReportType;
 import com.grepp.teamnotfound.app.model.report.dto.ReportDetailDto;
 import com.grepp.teamnotfound.app.model.report.entity.Report;
 import com.grepp.teamnotfound.app.model.report.repository.ReportRepository;
-import com.grepp.teamnotfound.app.model.user.code.UserStateResponse;
+//import com.grepp.teamnotfound.app.model.user.code.UserStateResponse;
+import com.grepp.teamnotfound.app.model.user.code.UserStatus;
 import com.grepp.teamnotfound.app.model.user.entity.User;
 import com.grepp.teamnotfound.infra.error.exception.BusinessException;
 import com.grepp.teamnotfound.infra.error.exception.code.BoardErrorCode;
@@ -108,8 +109,8 @@ class ReportServiceTest {
         assertThat(result.getBoardType()).isEqualTo(board.getName());
         assertThat(result.getReporterNickname()).isEqualTo(reporter.getNickname());
         assertThat(result.getReportedNickname()).isEqualTo(reported.getNickname());
-        assertThat(result.getReportedState()).isEqualTo(reported.getUserState());
-        assertThat(result.getReportedState()).isEqualTo(UserStateResponse.ACTIVE);
+        assertThat(result.getReportedState()).isEqualTo(reported.getStatus());
+        assertThat(result.getReportedState()).isEqualTo(UserStatus.ACTIVE);
 
         // replyRepository의 메소드는 호출되지 않았는지
         verify(replyRepository, never()).findArticleWithBoardByReplyId(anyLong());
@@ -247,6 +248,6 @@ class ReportServiceTest {
         ReportDetailDto result = reportService.getReportDetail(reportId);
 
         // then
-        assertThat(result.getReportedState()).isEqualTo(UserStateResponse.LEAVE);
+        assertThat(result.getReportedState()).isEqualTo(UserStatus.LEAVE);
     }
 }


### PR DESCRIPTION
## ✅ PR 올리기 전에
- [x] `dev`에서 `pull` 받았나요?
- [x] `merge conflict` 발생 시, 해결하고 올리셨나요?
- [x] 자신이 작업한 `changes`만 존재하나요?
- [ ] 작업 중 DB 변경이 발생했나요?

## 🐶 구현한 기능
- **좋아요 요청 동시성 문제 해결**
- **배치 처리 로직 개선**

## 🔎 작업 내용
📍**좋아요 요청 동시성 문제 해결**
- **(문제 상황)** 기존의 로직은 서버 인스턴스가 여러 개일 때에 대한 고려가 없었음
- **(예시)** 1, 2, 3번 게시글에 대한 좋아요 요청이 레디스에 저장됐을 때, 서버 인스턴스 A, B에서 연속적으로 배치 스케줄링이 실행될 경우 두 인스턴스 모두 1, 2, 3번 게시글에 대한 요청이 있었다고 인식하고 DB에 2개씩 저장되는 문제가 발생
- **(해결 과정)** **Redisson의 분산 락(Distributed Lock)** 을 활용. 기본 Redis에서도 분산 락 기능은 제공하지만 직접 락 획득, 해제, 갱신 등의 과정을 구현해야 하기에 기본적인 추상화, 예외 처리가 구현된 Redisson을 선택했습니다. 관련해서 의존성과 설정 클래스를 추가했습니다.

📍**배치 처리 트랜잭션 단위 변경**
- **(문제 상황)** 기존 로직은 모든 좋아요 및 취소 요청에 대해 하나의 트랜잭션으로 다루었기에 롤백되는 범위가 너무 큼
- **(예시)** 10개의 요청 중 9개의 요청을 잘 처리하더라도 마지막 1개의 요청 처리에 오류가 발생하면 모두 롤백되는 문제
- **(해결 과정)** 따라서 트랜잭션 단위를 article 단위로 나누고, @Transactional은 AOP를 기반으로 동작하기에 **별도의 클래스에서 DB에 반영하는 메서드**를 다시 작성했습니다.

📍**배치 처리 실패 시 재시도 가능하도록 개선**
- **(문제 상황)** 배치 프로세서가 redis에 저장된 요청을 가져오면서 동시에 모두 비워버리기 때문에 배치 처리 중 오류가 발생하면 재시도가 불가능
- **(해결 과정)** 이를 개선하기 위해 요청 조회 & 삭제를 한 번에 처리하던 메서드를 분리했습니다. 배치 처리 전 저장된 요청을 가져오고, **트랜잭션이 정상적으로 완료되고 커밋됐을 때만 해당 요청을 삭제**합니다. 따라서 요청 처리가 실패했을 경우 redis에 그대로 남아있기 때문에 다음 스케줄링 때 재시도할 수 있습니다.

📍**인덱스 추가**
- 게시글, 댓글, 게시글 이미지, 게시글 좋아요 테이블에 **필터 조건**, **정렬 조건**으로 자주 사용되는 컬럼에 인덱스 추가

